### PR TITLE
Clean up some of the memory management code

### DIFF
--- a/src/bindings/node-liblzma.cpp
+++ b/src/bindings/node-liblzma.cpp
@@ -31,26 +31,7 @@ Nan::Persistent<Function> LZMA::constructor;
 	if (!self) { \
 		_failMissingSelf(info); \
 		return; \
-	} \
-	struct _MemScopeGuard { \
-		_MemScopeGuard(LZMA* self_) : self(self_) {} \
-		~_MemScopeGuard() { \
-			self->reportAdjustedExternalMemoryToV8(); \
-		} \
-		\
-		LZMA* self; \
-	}; \
-	_MemScopeGuard guard(self);
-
-void LZMA::reportAdjustedExternalMemoryToV8() {
-#ifdef LZMA_ASYNC_AVAILABLE
-	if (nonAdjustedExternalMemory == 0)
-		return;
-
-	Nan::AdjustExternalMemory(nonAdjustedExternalMemory);
-	nonAdjustedExternalMemory = 0;
-#endif
-}
+	}
 
 void LZMA::Close() {
   if(_wip) {

--- a/src/bindings/node-liblzma.hpp
+++ b/src/bindings/node-liblzma.hpp
@@ -59,10 +59,6 @@ using v8::Value;
 # define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
-#if NODE_MODULE_VERSION >= 11
-#define LZMA_ASYNC_AVAILABLE
-#endif
-
 /**
  * Create a new v8 String
  */
@@ -81,6 +77,7 @@ private:
   {
   }
   ~LZMA() {
+    Nan::AdjustExternalMemory(-int64_t(sizeof(LZMA)));
     Close();
   }
 
@@ -93,7 +90,6 @@ private:
   static NAN_METHOD(Code);
 
 private:
-  void reportAdjustedExternalMemoryToV8();
   static void Process(uv_work_t* work_req);
   static void After(uv_work_t* work_req, int status);
   static Local<Value> AfterSync(LZMA* obj);
@@ -114,7 +110,6 @@ private:
   lzma_action _action;
   Nan::Callback _callback;
   lzma_ret _ret;
-  int64_t nonAdjustedExternalMemory;
 };
 
 #endif // NODE_LIBLZMA_H


### PR DESCRIPTION
Hi there!

Glad to see some parts of my lzma-native bindings were helpful to you! I would like to propose a few simplifications/fixes though:

* Leave out `_MemScopeGuard`, `reportAdjustedExternalMemoryToV8` etc.; these code bits were only used in conjunction with asynchronous coding (as implemented in lzma-native, not as implemented here) and the custom memory allocator which was passed to liblzma. You don’t need them in your code, at least as long as you are not going to copy the mentioned functionality, too.
* Add call to `Nan::AdjustExternalMemory` in `LZMA::~LZMA`, since there is an corresponding call in `LZMA::New`, and telling V8 only about increases in externally allocated memory will make it believe that memory is not getting freed.