### PR TITLE
Use the module’s name in `NODE_MODULE(…)`

### DIFF
--- a/src/bindings/module.cpp
+++ b/src/bindings/module.cpp
@@ -105,4 +105,4 @@ void moduleInit(Local<Object> exports) {
 	// exports->Set(NewString("asyncCodeAvailable"),       Nan::New<Boolean>(LZMAStream::asyncCodeAvailable));
 }
 
-NODE_MODULE(lzma_native, moduleInit)
+NODE_MODULE(node_liblzma, moduleInit)

--- a/test/lzma_base.coffee
+++ b/test/lzma_base.coffee
@@ -8,7 +8,7 @@ describe 'Xz Compressor options', ->
     expect(->
       xzStream = new Xz filters: filter.LZMA2
     ).to.throwException (e) ->
-      expect(e).to.eql {"name":"AssertionError","actual":false,"expected":true,"operator":"==","message":"Filters need to be in an array!","generatedMessage":false}
+      expect(e.message).to.eql "Filters need to be in an array!"
 
   it 'should throw error if more than LZMA_MAX_FILTERS set', (done) ->
     expect(->


### PR DESCRIPTION
This seems to stop the `Error: Symbol node_liblzma_module not found.` error, although I keep getting segfaults for node v0.11