### PR TITLE
Fix node v0.11 segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.log
 deps/
 *.gz
+core

--- a/src/bindings/node-liblzma.cpp
+++ b/src/bindings/node-liblzma.cpp
@@ -297,7 +297,6 @@ void LZMA::After(uv_work_t* work_req, int status) {
 }
 
 Local<Value> LZMA::AfterSync(LZMA* obj) {
-	Nan::HandleScope scope;
   Local<Number> ret_code = Nan::New<Number>(obj->_ret);
   Local<Number> avail_in = Nan::New<Number>(obj->_stream.avail_in);
   Local<Number> avail_out = Nan::New<Number>(obj->_stream.avail_out);


### PR DESCRIPTION
There is no need to use a `HandleScope` here – in fact, it being there meant that all `Local`s in `LZMA::AfterSync` were considered unused by V8 after the function was done executing, and therefore using `result` lead to undefined behaviour, such as segfault. Since `LZMA::AfterSync` is called from `LZMA::Code`, which already defines a `HandleScope`, the line can safely be omitted.