### PR TITLE
Update xz version (fixes 404 error on fetch).

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -9,8 +9,8 @@ settings:
     env:
       CPPFLAGS: "-fPIC"
       CFLAGS: "-O3"
-  xzWebUrl: 'http://tukaani.org/xz/xz'
-  xzVersion: '5.2.2'
+  xzWebUrl: 'http://tukaani.org/xz'
+  xzVersion: '5.2.3'
   xzExt: 'gz'
   clean:
     path: ['lib', '*.log']

--- a/build.yml
+++ b/build.yml
@@ -37,7 +37,7 @@ build_lzma:
   - rm -rf deps
   - task: fetch_lzma
   - cd deps/xz
-  - ./autogen.sh
+  # - ./autogen.sh
   - ./configure --prefix=`pwd` --enable-threads --enable-static --disable-shared --disable-scripts --disable-lzmainfo
     --disable-lzma-links --disable-lzmadec --disable-xzdec --disable-xz --disable-rpath
   - make

--- a/build.yml
+++ b/build.yml
@@ -9,7 +9,7 @@ settings:
     env:
       CPPFLAGS: "-fPIC"
       CFLAGS: "-O3"
-  xzWebUrl: 'http://tukaani.org/xz'
+  xzWebUrl: 'http://tukaani.org/xz/xz'
   xzVersion: '5.2.3'
   xzExt: 'gz'
   clean:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/oorabona/node-liblzma",
   "dependencies": {
+    "coffee-script": "*",
     "nan": "latest",
     "node-pre-gyp": "latest",
     "ubs": "latest"

--- a/src/bindings/module.cpp
+++ b/src/bindings/module.cpp
@@ -98,8 +98,10 @@ void moduleInit(Local<Object> exports) {
   exports->Set(NewString("STREAM_ENCODE"),                  Nan::New<Number>(STREAM_ENCODE));
   exports->Set(NewString("STREAM_DECODE"),                  Nan::New<Number>(STREAM_DECODE));
 #ifdef LIBLZMA_ENABLE_MT
-  exports->Set(NewString("STREAM_ENCODE_MT"),                  Nan::New<Number>(STREAM_ENCODE_MT));
+  exports->Set(NewString("STREAM_ENCODE_MT"),              	Nan::New<Number>(STREAM_ENCODE_MT));
 #endif
+  exports->Set(NewString("STREAM_ENCODE_RAW"),              Nan::New<Number>(STREAM_ENCODE_RAW));
+  exports->Set(NewString("STREAM_DECODE_RAW"),              Nan::New<Number>(STREAM_DECODE_RAW));
 
   exports->Set(NewString("BUFSIZ"),                  Nan::New<Number>(BUFSIZ));
 }

--- a/src/bindings/node-liblzma.cpp
+++ b/src/bindings/node-liblzma.cpp
@@ -135,6 +135,14 @@ NAN_METHOD(LZMA::New) {
       ret = lzma_stream_encoder(&self->_stream, filters, check);
       break;
     }
+    case STREAM_DECODE_RAW: {
+      ret = lzma_raw_decoder(&self->_stream, filters);
+      break;
+    }
+    case STREAM_ENCODE_RAW: {
+      ret = lzma_raw_encoder(&self->_stream, filters);
+      break;
+    }
 #ifdef LIBLZMA_ENABLE_MT
     case STREAM_ENCODE_MT: {
       unsigned int threads = opts->Get(NewString("threads"))->Uint32Value();

--- a/src/bindings/node-liblzma.hpp
+++ b/src/bindings/node-liblzma.hpp
@@ -50,6 +50,8 @@ using v8::Value;
 #define STREAM_ENCODE 0
 #define STREAM_DECODE 1
 #define STREAM_ENCODE_MT 2
+#define STREAM_ENCODE_RAW 3
+#define STREAM_DECODE_RAW 4
 
 #define CONST_UINT32(target, value) \
   target->Set(String::NewSymbol(#value), Uint32::New(value), \


### PR DESCRIPTION
I have bumped the version and made it work on my build machine.

I had to comments out autogen.sh from the build and also add coffee-script to the list of package dependencies. Those changes might break other things or cause old bugs to resurface.

When liblzma updated they increased the automake version required so autogen will fail when autoconf is run now. I suspect autogen.sh was added for the sake of it because it's rare that's needed with source tarballs (the generated files are normally good).

Putting coffee script in the dependencies prevents an error message at the end of the build process (making javascript bindings). I'm not sure if that actually breaks the package but it looks bad to me.

There are still two errors reported after building liblzma but I see nothing wrong with it.