### PR TITLE
fix(ci): build separate macOS prebuilds for arm64 and x64

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -42,10 +42,16 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
+            arch: x64
           - os: macos-latest
-            target: darwin-x64+arm64
+            target: darwin-arm64
+            arch: arm64
+          - os: macos-13
+            target: darwin-x64
+            arch: x64
           - os: windows-latest
             target: win32-x64
+            arch: x64
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.target }}
     steps:
@@ -60,14 +66,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          architecture: x64
+          architecture: ${{ matrix.arch }}
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
       - name: Setup ccache (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: build-${{ runner.os }}-ccache
+          key: build-${{ matrix.target }}-ccache
           max-size: 500M
       - name: Setup pnpm store cache
         uses: actions/cache@v5
@@ -76,9 +82,9 @@ jobs:
             ~/.local/share/pnpm/store
             ~/Library/pnpm/store
             ~\AppData\Local\pnpm\store
-          key: build-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: build-${{ matrix.target }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            build-${{ runner.os }}-pnpm-store-
+            build-${{ matrix.target }}-pnpm-store-
       - name: Setup xz deps cache
         uses: actions/cache@v5
         id: xz-cache
@@ -87,9 +93,9 @@ jobs:
             deps/xz
             deps/xz.tar.gz
             build/liblzma
-          key: build-${{ runner.os }}-xz-default-${{ hashFiles('scripts/download_xz_from_github.py', 'xz-version.json') }}
+          key: build-${{ matrix.target }}-xz-default-${{ hashFiles('scripts/download_xz_from_github.py', 'xz-version.json') }}
           restore-keys: |
-            build-${{ runner.os }}-xz-
+            build-${{ matrix.target }}-xz-
 
       - name: Download XZ from artifact or fallback
         if: steps.xz-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- Split single macOS matrix entry (`darwin-x64+arm64`) into two separate jobs: `darwin-arm64` (macos-latest) and `darwin-x64` (macos-13)
- Use `matrix.arch` for `setup-node` architecture instead of hardcoded `x64`
- Scope all cache keys by `matrix.target` instead of `runner.os` to prevent cross-architecture cache pollution

## Why
The previous setup only produced x64 prebuilds despite the target name suggesting both architectures. `macos-latest` runs on ARM64 runners, but `architecture: x64` forced an x64 Node.js — prebuildify builds for the running Node arch, not the host CPU.

## Test plan
- [ ] CI matrix shows 4 jobs: linux-x64, darwin-arm64, darwin-x64, win32-x64
- [ ] darwin-arm64 job produces ARM64 prebuild artifact
- [ ] darwin-x64 job produces x64 prebuild artifact
- [ ] Cache keys are distinct per target (no cross-arch pollution)