### PR TITLE
chore(deps-dev): bump typedoc from 0.28.18 to 0.28.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "release-it": "^19.2.4",
     "simple-git-hooks": "^2.13.1",
     "tsd": "^0.33.0",
-    "typedoc": "^0.28.17",
+    "typedoc": "^0.28.19",
     "typedoc-material-theme": "^1.4.1",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0
       typedoc:
-        specifier: ^0.28.17
+        specifier: ^0.28.19
         version: 0.28.19(typescript@6.0.3)
       typedoc-material-theme:
         specifier: ^1.4.1


### PR DESCRIPTION
Test PR to validate CodeQL paths-ignore on dep-only changes. If this PR can merge without admin, fire-and-forget works.