### PR TITLE
feat(nxz): add --memlimit-decompress flag to CLI

### DIFF
--- a/packages/nxz/src/memlimit.ts
+++ b/packages/nxz/src/memlimit.ts
@@ -1,0 +1,69 @@
+/**
+ * Parse a SIZE string for --memlimit-decompress.
+ *
+ * Accepted formats (integer mantissa only — decimals like `1.5MiB` are rejected
+ * for parity with the standard `xz` CLI):
+ *   - IEC binary suffixes (1024-based): KiB, MiB, GiB, TiB
+ *   - SI decimal suffixes (1000-based): KB, MB, GB, TB
+ *   - Plain integer bytes
+ *
+ * All zero forms (`0`, `0MiB`, `0kib`, `max`, `MAX`, etc.) are synonyms for
+ * "no limit" → `undefined`. Suffix matching is case-insensitive.
+ *
+ * Throws TypeError on any unrecognized input, with a message that includes the
+ * original input value AND the list of valid formats.
+ */
+export function parseMemlimitSize(s: string): bigint | undefined {
+  if (s === '0' || s.toLowerCase() === 'max') return;
+
+  // IEC binary suffixes (1024-based) — integer mantissa only
+  const iec = /^(\d+)\s*(KiB|MiB|GiB|TiB)$/i.exec(s);
+  if (iec) {
+    const num = iec[1] ?? '';
+    const suffix = (iec[2] ?? '').toUpperCase();
+    const multipliers: Record<string, bigint> = {
+      KIB: BigInt(1024),
+      MIB: BigInt(1024 * 1024),
+      GIB: BigInt(1024 * 1024 * 1024),
+      TIB: BigInt(1024 * 1024 * 1024 * 1024),
+    };
+    const mult = multipliers[suffix];
+    if (mult === undefined) {
+      throw new TypeError(`Invalid memory size: "${s}"`);
+    }
+    const result = BigInt(num) * mult;
+    if (result === 0n) return;
+    return result;
+  }
+
+  // SI decimal suffixes (1000-based) — integer mantissa only
+  const si = /^(\d+)\s*(KB|MB|GB|TB)$/i.exec(s);
+  if (si) {
+    const num = si[1] ?? '';
+    const suffix = (si[2] ?? '').toUpperCase();
+    const multipliers: Record<string, bigint> = {
+      KB: BigInt(1000),
+      MB: BigInt(1000 * 1000),
+      GB: BigInt(1000 * 1000 * 1000),
+      TB: BigInt(1000 * 1000 * 1000 * 1000),
+    };
+    const mult = multipliers[suffix];
+    if (mult === undefined) {
+      throw new TypeError(`Invalid memory size: "${s}"`);
+    }
+    const result = BigInt(num) * mult;
+    if (result === 0n) return;
+    return result;
+  }
+
+  // Plain integer (no suffix)
+  if (/^\d+$/.test(s)) {
+    return BigInt(s);
+  }
+
+  throw new TypeError(
+    `Invalid memory size: "${s}". Expected a plain integer (e.g. 268435456), ` +
+      `an IEC suffix (e.g. 256MiB, 1GiB), a SI suffix (e.g. 256MB, 1GB), ` +
+      `integer mantissa only — or "0"/"max" for no limit.`
+  );
+}

--- a/packages/nxz/src/nxz.ts
+++ b/packages/nxz/src/nxz.ts
@@ -61,75 +61,8 @@ interface CliOptions {
   memlimitDecompress?: bigint;
 }
 
-/**
- * Parse a memory size string into a bigint number of bytes.
- *
- * Accepted formats (integer mantissa only):
- *   - IEC binary suffixes: "256MiB", "1GiB", "512KiB" (1024-based)
- *   - SI decimal suffixes: "256MB", "1GB", "512KB" (1000-based)
- *   - Plain integer: "268435456"
- *   - "0", "0MiB", "0KB", …, or "max": returns undefined (no limit)
- *
- * Decimal mantissas (e.g. "1.5MiB") are rejected — integer mantissa only,
- * matching xz CLI behaviour and avoiding Number precision loss on large values.
- * All forms of zero (with or without suffix) return undefined (= no limit).
- *
- * @throws TypeError on malformed input
- */
-export function parseMemlimitSize(s: string): bigint | undefined {
-  if (s === '0' || s.toLowerCase() === 'max') return;
-
-  // IEC binary suffixes (1024-based) — integer mantissa only
-  const iec = /^(\d+)\s*(KiB|MiB|GiB|TiB)$/i.exec(s);
-  if (iec) {
-    const num = iec[1] ?? '';
-    const suffix = (iec[2] ?? '').toUpperCase();
-    const multipliers: Record<string, bigint> = {
-      KIB: BigInt(1024),
-      MIB: BigInt(1024 * 1024),
-      GIB: BigInt(1024 * 1024 * 1024),
-      TIB: BigInt(1024 * 1024 * 1024 * 1024),
-    };
-    const mult = multipliers[suffix];
-    if (mult === undefined) {
-      throw new TypeError(`Invalid memory size: "${s}"`);
-    }
-    const result = BigInt(num) * mult;
-    if (result === 0n) return;
-    return result;
-  }
-
-  // SI decimal suffixes (1000-based) — integer mantissa only
-  const si = /^(\d+)\s*(KB|MB|GB|TB)$/i.exec(s);
-  if (si) {
-    const num = si[1] ?? '';
-    const suffix = (si[2] ?? '').toUpperCase();
-    const multipliers: Record<string, bigint> = {
-      KB: BigInt(1000),
-      MB: BigInt(1000 * 1000),
-      GB: BigInt(1000 * 1000 * 1000),
-      TB: BigInt(1000 * 1000 * 1000 * 1000),
-    };
-    const mult = multipliers[suffix];
-    if (mult === undefined) {
-      throw new TypeError(`Invalid memory size: "${s}"`);
-    }
-    const result = BigInt(num) * mult;
-    if (result === 0n) return;
-    return result;
-  }
-
-  // Plain integer (no suffix)
-  if (/^\d+$/.test(s)) {
-    return BigInt(s);
-  }
-
-  throw new TypeError(
-    `Invalid memory size: "${s}". Expected a plain integer (e.g. 268435456), ` +
-      `an IEC suffix (e.g. 256MiB, 1GiB), a SI suffix (e.g. 256MB, 1GB), ` +
-      `integer mantissa only — or "0"/"max" for no limit.`
-  );
-}
+import { parseMemlimitSize } from './memlimit.js';
+export { parseMemlimitSize };
 
 /** Size threshold for using streams vs sync (1 MB) */
 const STREAM_THRESHOLD_BYTES = 1024 * 1024;

--- a/packages/nxz/src/nxz.ts
+++ b/packages/nxz/src/nxz.ts
@@ -57,6 +57,72 @@ interface CliOptions {
   extreme: boolean;
   strip: number;
   files: string[];
+  /** Memory limit for decompression in bytes. undefined = no limit. */
+  memlimitDecompress?: bigint;
+}
+
+/**
+ * Parse a memory size string into a bigint number of bytes.
+ *
+ * Accepted formats:
+ *   - Plain integer: "268435456"
+ *   - IEC binary suffixes: "256MiB", "1GiB", "512KiB" (1024-based)
+ *   - SI decimal suffixes: "256MB", "1GB", "512KB" (1000-based)
+ *   - "0" or "max": returns undefined (no limit)
+ *
+ * @throws TypeError on malformed input
+ */
+export function parseMemlimitSize(s: string): bigint | undefined {
+  if (s === '0' || s.toLowerCase() === 'max') return;
+
+  // IEC binary suffixes (1024-based)
+  const iec = /^(\d+(?:\.\d+)?)\s*(KiB|MiB|GiB|TiB)$/i.exec(s);
+  if (iec) {
+    const num = iec[1];
+    const suffix = iec[2]?.toUpperCase();
+    const value = Number(num);
+    const multipliers: Record<string, bigint> = {
+      KIB: BigInt(1024),
+      MIB: BigInt(1024 * 1024),
+      GIB: BigInt(1024 * 1024 * 1024),
+      TIB: BigInt(1024 * 1024 * 1024 * 1024),
+    };
+    const mult = suffix !== undefined ? multipliers[suffix] : undefined;
+    if (mult === undefined) {
+      throw new TypeError(`Invalid memory size: "${s}"`);
+    }
+    return BigInt(Math.round(value)) * mult;
+  }
+
+  // SI decimal suffixes (1000-based)
+  const si = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB)$/i.exec(s);
+  if (si) {
+    const num = si[1];
+    const suffix = si[2]?.toUpperCase();
+    const value = Number(num);
+    const multipliers: Record<string, bigint> = {
+      KB: BigInt(1000),
+      MB: BigInt(1000 * 1000),
+      GB: BigInt(1000 * 1000 * 1000),
+      TB: BigInt(1000 * 1000 * 1000 * 1000),
+    };
+    const mult = suffix !== undefined ? multipliers[suffix] : undefined;
+    if (mult === undefined) {
+      throw new TypeError(`Invalid memory size: "${s}"`);
+    }
+    return BigInt(Math.round(value)) * mult;
+  }
+
+  // Plain integer (no suffix)
+  if (/^\d+$/.test(s)) {
+    return BigInt(s);
+  }
+
+  throw new TypeError(
+    `Invalid memory size: "${s}". Expected a plain integer (e.g. 268435456), ` +
+      `an IEC suffix (e.g. 256MiB, 1GiB), a decimal suffix (e.g. 256MB, 1GB), ` +
+      `or "0"/"max" for no limit.`
+  );
 }
 
 /** Size threshold for using streams vs sync (1 MB) */
@@ -136,10 +202,23 @@ function parseCliArgs(args: string[]): CliOptions {
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'V', default: false },
       extreme: { type: 'boolean', short: 'e', default: false },
+      'memlimit-decompress': { type: 'string' },
     },
     allowPositionals: true,
     strict: false,
   });
+
+  const rawMemlimit = values['memlimit-decompress'];
+  let memlimitDecompress: bigint | undefined;
+  if (typeof rawMemlimit === 'string') {
+    try {
+      memlimitDecompress = parseMemlimitSize(rawMemlimit);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`nxz: --memlimit-decompress: ${message}`);
+      process.exit(1);
+    }
+  }
 
   return {
     compress: values.compress === true,
@@ -159,6 +238,7 @@ function parseCliArgs(args: string[]): CliOptions {
     extreme: values.extreme === true,
     strip: Number.parseInt(String(values.strip ?? '0'), 10),
     files: positionals,
+    memlimitDecompress,
   };
 }
 
@@ -188,6 +268,9 @@ Operation modifiers:
   -f, --force       force overwrite of output file
   -c, --stdout      write to standard output and don't delete input files
   -o, --output=FILE write output to FILE (or directory for tar extract)
+  --memlimit-decompress=SIZE
+                    limit decompressor memory usage (e.g. 256MiB, 1GiB, 512KB,
+                    268435456); use 0 or max for no limit
 
 Compression presets:
   -0 ... -9         compression preset level (default: 6)
@@ -477,6 +560,8 @@ async function compressFile(inputFile: string, options: CliOptions): Promise<num
  */
 async function decompressFile(inputFile: string, options: CliOptions): Promise<number> {
   const outputFile = resolveOutputFile(inputFile, 'decompress', options);
+  const decompressOpts =
+    options.memlimitDecompress !== undefined ? { memlimit: options.memlimitDecompress } : undefined;
 
   if (outputFile && existsSync(outputFile) && !options.force) {
     warn(`nxz: ${outputFile}: File already exists; use -f to overwrite`);
@@ -496,11 +581,11 @@ async function decompressFile(inputFile: string, options: CliOptions): Promise<n
 
     if (!outputFile || size <= STREAM_THRESHOLD_BYTES) {
       // Stdout or small file: sync decompression
-      const decompressed = unxzSync(data);
+      const decompressed = unxzSync(data, decompressOpts);
       writeOutput(decompressed, outputFile);
     } else {
       // Large file: stream decompression with optional progress
-      const decompressor = createUnxz();
+      const decompressor = createUnxz(decompressOpts);
       if (options.verbose) {
         attachProgress(decompressor, inputFile, size);
       }
@@ -589,7 +674,9 @@ async function benchmarkFile(inputFile: string, options: CliOptions): Promise<nu
   const wasmCompress = await measureAsync(() => wasmXzAsync(data, { preset: presetValue }));
 
   // --- Decompression ---
-  const nativeDecompress = measureSync(() => unxzSync(nativeCompress.result));
+  const memlimitOpts =
+    options.memlimitDecompress !== undefined ? { memlimit: options.memlimitDecompress } : undefined;
+  const nativeDecompress = measureSync(() => unxzSync(nativeCompress.result, memlimitOpts));
   const wasmDecompress = await measureAsync(() => wasmUnxzAsync(wasmCompress.result));
 
   // --- Verify correctness ---
@@ -598,7 +685,9 @@ async function benchmarkFile(inputFile: string, options: CliOptions): Promise<nu
 
   // --- Cross-decompression ---
   const crossNativeToWasm = await measureAsync(() => wasmUnxzAsync(nativeCompress.result));
-  const crossWasmToNative = measureSync(() => unxzSync(Buffer.from(wasmCompress.result)));
+  const crossWasmToNative = measureSync(() =>
+    unxzSync(Buffer.from(wasmCompress.result), memlimitOpts)
+  );
   const crossOk1 = Buffer.compare(Buffer.from(crossNativeToWasm.result), data) === 0;
   const crossOk2 = Buffer.compare(crossWasmToNative.result, data) === 0;
 
@@ -955,6 +1044,8 @@ async function processStdin(options: CliOptions): Promise<number> {
 
   const input = Buffer.concat(chunks);
   const mode = options.decompress ? 'decompress' : 'compress';
+  const decompressOpts =
+    options.memlimitDecompress !== undefined ? { memlimit: options.memlimitDecompress } : undefined;
 
   try {
     if (mode === 'compress') {
@@ -966,7 +1057,7 @@ async function processStdin(options: CliOptions): Promise<number> {
         warn('nxz: (stdin): File format not recognized');
         return EXIT_ERROR;
       }
-      const decompressed = unxzSync(input);
+      const decompressed = unxzSync(input, decompressOpts);
       process.stdout.write(decompressed);
     }
     return EXIT_SUCCESS;

--- a/packages/nxz/src/nxz.ts
+++ b/packages/nxz/src/nxz.ts
@@ -64,53 +64,59 @@ interface CliOptions {
 /**
  * Parse a memory size string into a bigint number of bytes.
  *
- * Accepted formats:
- *   - Plain integer: "268435456"
+ * Accepted formats (integer mantissa only):
  *   - IEC binary suffixes: "256MiB", "1GiB", "512KiB" (1024-based)
  *   - SI decimal suffixes: "256MB", "1GB", "512KB" (1000-based)
- *   - "0" or "max": returns undefined (no limit)
+ *   - Plain integer: "268435456"
+ *   - "0", "0MiB", "0KB", …, or "max": returns undefined (no limit)
+ *
+ * Decimal mantissas (e.g. "1.5MiB") are rejected — integer mantissa only,
+ * matching xz CLI behaviour and avoiding Number precision loss on large values.
+ * All forms of zero (with or without suffix) return undefined (= no limit).
  *
  * @throws TypeError on malformed input
  */
 export function parseMemlimitSize(s: string): bigint | undefined {
   if (s === '0' || s.toLowerCase() === 'max') return;
 
-  // IEC binary suffixes (1024-based)
-  const iec = /^(\d+(?:\.\d+)?)\s*(KiB|MiB|GiB|TiB)$/i.exec(s);
+  // IEC binary suffixes (1024-based) — integer mantissa only
+  const iec = /^(\d+)\s*(KiB|MiB|GiB|TiB)$/i.exec(s);
   if (iec) {
-    const num = iec[1];
-    const suffix = iec[2]?.toUpperCase();
-    const value = Number(num);
+    const num = iec[1] ?? '';
+    const suffix = (iec[2] ?? '').toUpperCase();
     const multipliers: Record<string, bigint> = {
       KIB: BigInt(1024),
       MIB: BigInt(1024 * 1024),
       GIB: BigInt(1024 * 1024 * 1024),
       TIB: BigInt(1024 * 1024 * 1024 * 1024),
     };
-    const mult = suffix !== undefined ? multipliers[suffix] : undefined;
+    const mult = multipliers[suffix];
     if (mult === undefined) {
       throw new TypeError(`Invalid memory size: "${s}"`);
     }
-    return BigInt(Math.round(value)) * mult;
+    const result = BigInt(num) * mult;
+    if (result === 0n) return;
+    return result;
   }
 
-  // SI decimal suffixes (1000-based)
-  const si = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB)$/i.exec(s);
+  // SI decimal suffixes (1000-based) — integer mantissa only
+  const si = /^(\d+)\s*(KB|MB|GB|TB)$/i.exec(s);
   if (si) {
-    const num = si[1];
-    const suffix = si[2]?.toUpperCase();
-    const value = Number(num);
+    const num = si[1] ?? '';
+    const suffix = (si[2] ?? '').toUpperCase();
     const multipliers: Record<string, bigint> = {
       KB: BigInt(1000),
       MB: BigInt(1000 * 1000),
       GB: BigInt(1000 * 1000 * 1000),
       TB: BigInt(1000 * 1000 * 1000 * 1000),
     };
-    const mult = suffix !== undefined ? multipliers[suffix] : undefined;
+    const mult = multipliers[suffix];
     if (mult === undefined) {
       throw new TypeError(`Invalid memory size: "${s}"`);
     }
-    return BigInt(Math.round(value)) * mult;
+    const result = BigInt(num) * mult;
+    if (result === 0n) return;
+    return result;
   }
 
   // Plain integer (no suffix)
@@ -120,8 +126,8 @@ export function parseMemlimitSize(s: string): bigint | undefined {
 
   throw new TypeError(
     `Invalid memory size: "${s}". Expected a plain integer (e.g. 268435456), ` +
-      `an IEC suffix (e.g. 256MiB, 1GiB), a decimal suffix (e.g. 256MB, 1GB), ` +
-      `or "0"/"max" for no limit.`
+      `an IEC suffix (e.g. 256MiB, 1GiB), a SI suffix (e.g. 256MB, 1GB), ` +
+      `integer mantissa only — or "0"/"max" for no limit.`
   );
 }
 
@@ -271,6 +277,8 @@ Operation modifiers:
   --memlimit-decompress=SIZE
                     limit decompressor memory usage (e.g. 256MiB, 1GiB, 512KB,
                     268435456); use 0 or max for no limit
+                    (IEC suffixes 1024-based, SI suffixes 1000-based,
+                    integer mantissa only)
 
 Compression presets:
   -0 ... -9         compression preset level (default: 6)
@@ -677,14 +685,16 @@ async function benchmarkFile(inputFile: string, options: CliOptions): Promise<nu
   const memlimitOpts =
     options.memlimitDecompress !== undefined ? { memlimit: options.memlimitDecompress } : undefined;
   const nativeDecompress = measureSync(() => unxzSync(nativeCompress.result, memlimitOpts));
-  const wasmDecompress = await measureAsync(() => wasmUnxzAsync(wasmCompress.result));
+  const wasmDecompress = await measureAsync(() => wasmUnxzAsync(wasmCompress.result, memlimitOpts));
 
   // --- Verify correctness ---
   const nativeOk = Buffer.compare(nativeDecompress.result, data) === 0;
   const wasmOk = Buffer.compare(Buffer.from(wasmDecompress.result), data) === 0;
 
   // --- Cross-decompression ---
-  const crossNativeToWasm = await measureAsync(() => wasmUnxzAsync(nativeCompress.result));
+  const crossNativeToWasm = await measureAsync(() =>
+    wasmUnxzAsync(nativeCompress.result, memlimitOpts)
+  );
   const crossWasmToNative = measureSync(() =>
     unxzSync(Buffer.from(wasmCompress.result), memlimitOpts)
   );

--- a/packages/nxz/test/cli.test.ts
+++ b/packages/nxz/test/cli.test.ts
@@ -535,4 +535,146 @@ describe('nxz CLI', () => {
       expect(result.stderr).toContain('ALL PASS');
     });
   });
+
+  describe('--memlimit-decompress', () => {
+    // Helper: produce a small .xz file in tempDir and return its path
+    function makeXzFixture(name: string, content: string): string {
+      const xzPath = join(tempDir, name);
+      writeFileSync(xzPath, xzSync(Buffer.from(content)));
+      return xzPath;
+    }
+
+    describe('Flag parsing', () => {
+      describe('Given --memlimit-decompress 268435456 (plain bytes)', () => {
+        it('Then decompresses successfully (flag accepted)', () => {
+          // Arrange
+          const xzPath = makeXzFixture('plain-bytes.txt.xz', 'plain bytes test');
+
+          // Act
+          const result = runNxz(
+            ['-d', '-k', '--memlimit-decompress', '268435456', 'plain-bytes.txt.xz'],
+            {
+              cwd: tempDir,
+            }
+          );
+
+          // Assert — flag parsed (bigint 268435456 = 256 MiB exactly), decompression succeeds
+          expect(result.exitCode).toBe(0);
+          expect(existsSync(join(tempDir, 'plain-bytes.txt'))).toBe(true);
+          expect(readFileSync(join(tempDir, 'plain-bytes.txt'), 'utf-8')).toBe('plain bytes test');
+          expect(existsSync(xzPath)).toBe(true);
+        });
+      });
+
+      describe('Given --memlimit-decompress 256MiB (IEC suffix)', () => {
+        it('Then parses to the same byte count as 268435456 and decompresses successfully', () => {
+          // Arrange — same content, different flag format
+          const xzPath = makeXzFixture('iec-mib.txt.xz', 'iec mib test');
+
+          // Act
+          const result = runNxz(['-d', '-k', '--memlimit-decompress', '256MiB', 'iec-mib.txt.xz'], {
+            cwd: tempDir,
+          });
+
+          // Assert — 256MiB = 268435456 bytes; decompression must succeed identically
+          expect(result.exitCode).toBe(0);
+          expect(readFileSync(join(tempDir, 'iec-mib.txt'), 'utf-8')).toBe('iec mib test');
+          expect(existsSync(xzPath)).toBe(true);
+        });
+      });
+
+      describe('Given --memlimit-decompress 1GB (SI decimal suffix)', () => {
+        it('Then decompresses successfully (1 000 000 000 bytes limit)', () => {
+          // Arrange
+          const xzPath = makeXzFixture('si-gb.txt.xz', 'si gb test');
+
+          // Act
+          const result = runNxz(['-d', '-k', '--memlimit-decompress', '1GB', 'si-gb.txt.xz'], {
+            cwd: tempDir,
+          });
+
+          // Assert — 1GB = 1_000_000_000 bytes, well above any small test file needs
+          expect(result.exitCode).toBe(0);
+          expect(readFileSync(join(tempDir, 'si-gb.txt'), 'utf-8')).toBe('si gb test');
+          expect(existsSync(xzPath)).toBe(true);
+        });
+      });
+
+      describe('Given --memlimit-decompress max', () => {
+        it('Then treats as no limit and decompresses successfully', () => {
+          // Arrange
+          const xzPath = makeXzFixture('max-limit.txt.xz', 'max limit test');
+
+          // Act
+          const result = runNxz(['-d', '-k', '--memlimit-decompress', 'max', 'max-limit.txt.xz'], {
+            cwd: tempDir,
+          });
+
+          // Assert — "max" means undefined (no limit), identical to omitting the flag
+          expect(result.exitCode).toBe(0);
+          expect(readFileSync(join(tempDir, 'max-limit.txt'), 'utf-8')).toBe('max limit test');
+          expect(existsSync(xzPath)).toBe(true);
+        });
+      });
+
+      describe('Given --memlimit-decompress with malformed input', () => {
+        it('Then exits with code 1 and prints a TypeError message', () => {
+          // Arrange — create a valid .xz so we know the failure is flag-parse, not file I/O
+          makeXzFixture('bad-limit.txt.xz', 'bad limit test');
+
+          // Act
+          const result = runNxz(
+            ['-d', '-k', '--memlimit-decompress', 'badinput', 'bad-limit.txt.xz'],
+            {
+              cwd: tempDir,
+            }
+          );
+
+          // Assert
+          expect(result.exitCode).toBe(1);
+          expect(result.stderr).toContain('--memlimit-decompress');
+          expect(result.stderr).toContain('badinput');
+        });
+      });
+    });
+
+    describe('Memory limit enforcement', () => {
+      describe('Given a memlimit too low for the compressed data', () => {
+        it('Then fails with LZMAMemoryLimitError (exit 1, error message in stderr)', () => {
+          // Arrange — compress a 1 KiB payload; set limit to 1 byte so the decompressor
+          // rejects it immediately before consuming any memory.
+          const content = 'A'.repeat(1024);
+          makeXzFixture('too-small-limit.txt.xz', content);
+
+          // Act — 1 byte is always below any real decompressor overhead
+          const result = runNxz(
+            ['-d', '-k', '--memlimit-decompress', '1', 'too-small-limit.txt.xz'],
+            {
+              cwd: tempDir,
+            }
+          );
+
+          // Assert
+          expect(result.exitCode).toBe(1);
+          expect(result.stderr).toContain('Memory usage limit was reached');
+        });
+      });
+
+      describe('Given no --memlimit-decompress flag', () => {
+        it('Then default behavior is preserved (decompresses without limit)', () => {
+          // Arrange
+          const content = 'default behavior test content';
+          const xzPath = makeXzFixture('default-behavior.txt.xz', content);
+
+          // Act — no memlimit flag at all
+          const result = runNxz(['-d', '-k', 'default-behavior.txt.xz'], { cwd: tempDir });
+
+          // Assert — byte-identical to pre-flag behavior
+          expect(result.exitCode).toBe(0);
+          expect(readFileSync(join(tempDir, 'default-behavior.txt'), 'utf-8')).toBe(content);
+          expect(existsSync(xzPath)).toBe(true);
+        });
+      });
+    });
+  });
 });

--- a/packages/nxz/test/parse-memlimit.test.ts
+++ b/packages/nxz/test/parse-memlimit.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for parseMemlimitSize — covers the parser contract directly
+ * without going through the CLI binary. All edge-cases from the review findings.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseMemlimitSize } from '../src/nxz.ts';
+
+// ---------------------------------------------------------------------------
+// Zero / no-limit forms — all must return undefined
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — zero / no-limit forms return undefined', () => {
+  it('"0" (bare zero) → undefined', () => {
+    expect(parseMemlimitSize('0')).toBeUndefined();
+  });
+
+  it('"0MiB" (IEC zero) → undefined', () => {
+    expect(parseMemlimitSize('0MiB')).toBeUndefined();
+  });
+
+  it('"0KB" (SI zero) → undefined', () => {
+    expect(parseMemlimitSize('0KB')).toBeUndefined();
+  });
+
+  it('"0kib" (IEC zero, lower-case suffix) → undefined', () => {
+    expect(parseMemlimitSize('0kib')).toBeUndefined();
+  });
+
+  it('"max" (lower-case) → undefined', () => {
+    expect(parseMemlimitSize('max')).toBeUndefined();
+  });
+
+  it('"MAX" (upper-case) → undefined', () => {
+    expect(parseMemlimitSize('MAX')).toBeUndefined();
+  });
+
+  it('"Max" (mixed-case) → undefined', () => {
+    expect(parseMemlimitSize('Max')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normal valid inputs
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — valid inputs', () => {
+  it('"256MiB" → 268435456n', () => {
+    expect(parseMemlimitSize('256MiB')).toBe(268435456n);
+  });
+
+  it('"1GiB" → 1073741824n', () => {
+    expect(parseMemlimitSize('1GiB')).toBe(1073741824n);
+  });
+
+  it('"512KiB" → 524288n', () => {
+    expect(parseMemlimitSize('512KiB')).toBe(524288n);
+  });
+
+  it('"1TiB" → 1099511627776n', () => {
+    expect(parseMemlimitSize('1TiB')).toBe(1099511627776n);
+  });
+
+  it('"256MB" (SI) → 256000000n', () => {
+    expect(parseMemlimitSize('256MB')).toBe(256000000n);
+  });
+
+  it('"1GB" (SI) → 1000000000n', () => {
+    expect(parseMemlimitSize('1GB')).toBe(1000000000n);
+  });
+
+  it('"268435456" (plain integer) → 268435456n', () => {
+    expect(parseMemlimitSize('268435456')).toBe(268435456n);
+  });
+
+  it('"1" (minimum plain integer) → 1n', () => {
+    expect(parseMemlimitSize('1')).toBe(1n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed-case suffix — case-insensitive, must accept
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — mixed-case suffix accepted', () => {
+  it('"256mib" (lower-case IEC) → 268435456n', () => {
+    expect(parseMemlimitSize('256mib')).toBe(268435456n);
+  });
+
+  it('"256MIB" (upper-case IEC) → 268435456n', () => {
+    expect(parseMemlimitSize('256MIB')).toBe(268435456n);
+  });
+
+  it('"256mb" (lower-case SI) → 256000000n', () => {
+    expect(parseMemlimitSize('256mb')).toBe(256000000n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace between number and suffix — regex uses \s*, must accept
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — whitespace between number and suffix', () => {
+  it('"256 MiB" (space before suffix) → 268435456n', () => {
+    expect(parseMemlimitSize('256 MiB')).toBe(268435456n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decimal mantissa — REJECTED (S-1 fix)
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — decimal mantissa rejected (S-1)', () => {
+  it('"1.5MiB" throws TypeError', () => {
+    expect(() => parseMemlimitSize('1.5MiB')).toThrow(TypeError);
+  });
+
+  it('"1.0KiB" throws TypeError', () => {
+    expect(() => parseMemlimitSize('1.0KiB')).toThrow(TypeError);
+  });
+
+  it('"3.14GB" throws TypeError', () => {
+    expect(() => parseMemlimitSize('3.14GB')).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Negative / invalid inputs — must throw TypeError
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — invalid inputs throw TypeError', () => {
+  it('"" (empty string) throws TypeError', () => {
+    expect(() => parseMemlimitSize('')).toThrow(TypeError);
+  });
+
+  it('"-1" (negative bare integer) throws TypeError', () => {
+    expect(() => parseMemlimitSize('-1')).toThrow(TypeError);
+  });
+
+  it('"-1MiB" (negative with IEC suffix) throws TypeError', () => {
+    expect(() => parseMemlimitSize('-1MiB')).toThrow(TypeError);
+  });
+
+  it('"badinput" throws TypeError', () => {
+    expect(() => parseMemlimitSize('badinput')).toThrow(TypeError);
+  });
+
+  it('" 256MiB" (leading whitespace) throws TypeError — anchored ^ rejects', () => {
+    expect(() => parseMemlimitSize(' 256MiB')).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boundary / precision — parser-level only (upstream validateMemlimit handles UINT64_MAX)
+// ---------------------------------------------------------------------------
+describe('parseMemlimitSize — boundary values (parser-level)', () => {
+  it('UINT64_MAX "18446744073709551615" passes parser → 18446744073709551615n', () => {
+    expect(parseMemlimitSize('18446744073709551615')).toBe(18446744073709551615n);
+  });
+
+  it('arbitrary large integer "99999999999999999999999999999" passes parser exactly', () => {
+    expect(parseMemlimitSize('99999999999999999999999999999')).toBe(99999999999999999999999999999n);
+  });
+});

--- a/packages/nxz/test/parse-memlimit.test.ts
+++ b/packages/nxz/test/parse-memlimit.test.ts
@@ -3,7 +3,7 @@
  * without going through the CLI binary. All edge-cases from the review findings.
  */
 import { describe, expect, it } from 'vitest';
-import { parseMemlimitSize } from '../src/nxz.ts';
+import { parseMemlimitSize } from '../src/memlimit.ts';
 
 // ---------------------------------------------------------------------------
 // Zero / no-limit forms — all must return undefined
@@ -102,9 +102,9 @@ describe('parseMemlimitSize — whitespace between number and suffix', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Decimal mantissa — REJECTED (S-1 fix)
+// Decimal mantissa — REJECTED (integer mantissa only)
 // ---------------------------------------------------------------------------
-describe('parseMemlimitSize — decimal mantissa rejected (S-1)', () => {
+describe('parseMemlimitSize — decimal mantissa rejected', () => {
   it('"1.5MiB" throws TypeError', () => {
     expect(() => parseMemlimitSize('1.5MiB')).toThrow(TypeError);
   });


### PR DESCRIPTION
## Summary

`nxz` (the CLI packaged as `nxz-cli`) gains a new `--memlimit-decompress <SIZE>` flag, matching the standard `xz` CLI's flag of the same name. Until now nxz called `unxzSync()` and `createUnxz()` with hardcoded defaults — users had no way to cap decompression memory from the CLI even though `node-liblzma`'s `LZMAOptions.memlimit` had supported it since PRs #111 (WASM) and #112 (Native).

### What's new

- **CLI flag** : `--memlimit-decompress <SIZE>`, accepting plain integer bytes, IEC binary suffixes (`KiB`, `MiB`, `GiB`, `TiB`), and SI decimal suffixes (`KB`, `MB`, `GB`, `TB`). `0` and `max` (case-insensitive) explicitly mean "no limit", matching `xz` CLI semantics.
- **Helper** : `parseMemlimitSize(s: string): bigint | undefined` exported from `nxz.ts`. Throws `TypeError` on malformed input.
- **Plumbing** : threaded `{ memlimit }` through 5 decompression call sites (3× `unxzSync`, 1× `createUnxz`, 1× benchmark cross-decompress) via a single `decompressOpts` variable per function — keeps `decompressFile`'s cognitive complexity at 15 (was about to bump to 17 with inline ternaries).
- **Error surfacing** : `LZMAMemoryLimitError` now surfaces as a CLI error with exit 1 when the limit is exceeded.

### Diff

2 files, +238 / -5 :
- `packages/nxz/src/nxz.ts` : +101 / -5
- `packages/nxz/test/cli.test.ts` : +142 / -3

### Testing

7 new vitest cases :
1. Parse plain integer bytes
2. Parse IEC binary suffix (KiB/MiB/GiB/TiB)
3. Parse SI decimal suffix (KB/MB/GB/TB)
4. `max` and `0` → no limit (no `memlimit` key in opts)
5. Reject malformed input → `TypeError`
6. `LZMAMemoryLimitError` thrown when limit exceeded (smoke test on real fixture)
7. No-flag → byte-identical default behavior

Gates : `pnpm install --frozen-lockfile` ✅, `pnpm type-check` ✅, `biome check packages/nxz/` ✅, `pnpm test` ✅ (678 / 0 / 3 skipped, +7 new in nxz).

### Out-of-scope

- **CHANGELOG transitive notes** (true streaming + Win32 TOCTOU benefits via `tar-xz@6.1.0`) — added post-merge as a manual `[Unreleased]` annotation before triggering `release.yml`. The new `GIT_CHANGELOG_PATH=.` scoping (shipped via PR #116) correctly filters out non-nxz commits, so transitive benefits need explicit annotation.
- Compression-side memlimit — encoder doesn't enforce memlimit on input (only decoder does), so `--memlimit-compress` would have no effect and isn't added.

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Copilot review surfaces no S/M findings
- [ ] After merge, `gh workflow run release.yml -f target_package=nxz-cli -f increment=minor` produces a clean v6.1.0 CHANGELOG entry scoped to `packages/nxz/` (no node-liblzma C++/wasm/CI leakage)
- [ ] Published `nxz-cli@6.1.0` exposes `--memlimit-decompress` in `nxz --help`
