### PR TITLE
chore(deps): bump @oorabona/release-it-preset 0.11.0 → 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
-    "@oorabona/release-it-preset": "^0.11.0",
+    "@oorabona/release-it-preset": "^0.12.0",
     "@oorabona/vitest-monocart-coverage": "^2.0.1",
     "@types/node": "catalog:",
     "@vitest/coverage-istanbul": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 'catalog:'
         version: 2.4.13
       '@oorabona/release-it-preset':
-        specifier: ^0.11.0
-        version: 0.11.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))
+        specifier: ^0.12.0
+        version: 0.12.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))
       '@oorabona/vitest-monocart-coverage':
         specifier: ^2.0.1
         version: 2.0.1(vitest@4.1.5)
@@ -498,8 +498,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oorabona/release-it-preset@0.11.0':
-    resolution: {integrity: sha512-2fEd4v0rGX7VBhOZ7gnrDk7NUxa2XOeo9hU11vlZR/hVt5iuK+nQYdsnKv1kYTtTI12KL9kLm6cleoaK0hGXMQ==}
+  '@oorabona/release-it-preset@0.12.0':
+    resolution: {integrity: sha512-OrX1rxl8JIN34bqYFdHuxOf/FjfgE67vyNJaGFicgW0H7MSNv0+uOqHNnc3FtdFndOkFWbclLdKEqn3Vm8Sq8w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -2521,7 +2521,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oorabona/release-it-preset@0.11.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))':
+  '@oorabona/release-it-preset@0.12.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))':
     dependencies:
       release-it: 20.0.1(@types/node@25.6.0)(magicast@0.5.2)
 


### PR DESCRIPTION
## Summary

Consume upstream tag-baseline fix from `oorabona/release-it-preset` issue [#21](https://github.com/oorabona/release-it-preset/issues/21) (PR [#22](https://github.com/oorabona/release-it-preset/pull/22), squash `d117cad`, npm `v0.12.0` published 2026-04-30).

### What changes

The new `resolveSinceBaseline()` in `populate-unreleased-changelog.ts` :
- Detects per-package release commits matching `chore(<pkg>): release v*` and uses their SHA as the `since` baseline when `GIT_CHANGELOG_PATH` is set (already wired in our `release.yml` since PR #116).
- New `GIT_CHANGELOG_SINCE` env var as explicit override escape hatch.
- Falls back to `git describe --tags` for single-package consumers (no behavior change).

### Why it matters here

`nxz-cli@6.1.0` (released 2026-04-30) needed manual CHANGELOG curation (commit `9e30af4`) because the populate script picked up commits since the last GPG-signed root tag (`v5.0.0`). With this bump, future workspace releases auto-scope to the per-package baseline.

### Empirical verification

Local dry-run from `packages/nxz/` with `GIT_CHANGELOG_PATH=.` : populate script produces **zero diff** (working tree clean) — the resolver correctly stops at `ecff028 chore(nxz-cli): release v6.1.0` and finds no commits to add to `[Unreleased]`.

### Diff

2 files, +6 / -6 (package.json + pnpm-lock.yaml).

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Next `tar-xz` or `nxz-cli` release produces a CHANGELOG entry that does not need manual curation