### PR TITLE
chore(lint): remove dead biome suppression in tar-xz node-api spec

### DIFF
--- a/packages/tar-xz/test/node-api.spec.ts
+++ b/packages/tar-xz/test/node-api.spec.ts
@@ -246,7 +246,6 @@ describe('Node.js file API (v6)', () => {
 
       for await (const entry of extract(archive)) {
         // Partially consume entry.data first
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional drain
         for await (const _ of entry.data) {
           /* drain */
         }


### PR DESCRIPTION
## Summary

`packages/tar-xz/test/node-api.spec.ts:249` had `// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional drain` above a `for await` loop whose body contains `/* drain */` (a comment, not an empty block). The suppression never fired because biome treats the commented body as non-empty — the linter flagged it as `suppressions/unused`.

Drop the line, no behavior change.

### Diff
1 file, -1 line.

### Gates
- `pnpm --filter tar-xz build`: EXIT 0
- `pnpm exec biome check .`: EXIT 0 (1 warning remaining: pre-existing CC=17 on `parseMemlimitSize`, tracked separately)
- `pnpm test`: 707 pass / 0 fail / 3 skipped

## Test plan

- [ ] CI green
- [ ] No new biome warnings introduced