### PR TITLE
test(nxz): restore 100% coverage on memlimit.ts after parser refactor

### DIFF
--- a/packages/nxz/src/memlimit.ts
+++ b/packages/nxz/src/memlimit.ts
@@ -40,10 +40,12 @@ function parseSuffixed(
 ): bigint | null {
   const match = regex.exec(s);
   if (!match) return null;
-  const num = match[1] ?? '';
-  const suffix = (match[2] ?? '').toUpperCase();
+  const num = match[1] as string;
+  const suffix = (match[2] as string).toUpperCase();
   const mult = multipliers[suffix];
+  /* v8 ignore start: defensive fail-closed; regex + map keys are pre-aligned, branch unreachable */
   if (mult === undefined) return null;
+  /* v8 ignore stop */
   return BigInt(num) * mult;
 }
 


### PR DESCRIPTION
## Summary

PR #120 extract-method refactor introduced 3 defensive paths in `parseSuffixed` that vitest's v8 flagged as unreachable :

- `match[1] ?? ''` (L43) and `match[2] ?? ''` (L44) — fallbacks on regex capture groups that are guaranteed defined when `regex.exec()` returns non-null.
- `if (mult === undefined) return null` (L46) — guard required by TS `noUncheckedIndexedAccess` but structurally unreachable since the regex constrains the suffix to keys present in the multiplier map.

### Fix

- L43, L44 : replace `?? ''` with `as string` type assertion. Compile-time only, no runtime branch for v8 to instrument. Not flagged by biome's `noNonNullAssertion` rule (unlike `!` which we explicitly avoided in PR #117 fix-round 1).
- L46 : wrap with `/* v8 ignore start ... stop */` pair (per project convention — never `next` per [`feedback_simple_git_hooks_over_husky.md`](https://github.com/oorabona/claude/blob/master/memory/feedback_simple_git_hooks_over_husky.md) lessons).

### Coverage

| Metric | Before | After |
|--------|--------|-------|
| Lines  | 95.2% (20/21) | **100% (19/19)** |
| Branches | 83.3% (15/18) | **100% (15/15)** |

### Diff

1 file, +4 / -2.

### Gates

- `pnpm install --frozen-lockfile`: EXIT 0
- `pnpm --filter nxz-cli build`: EXIT 0
- `pnpm type-check`: EXIT 0
- `pnpm exec biome check .`: EXIT 0, 0 warnings
- `pnpm test`: 707 pass / 0 fail / 3 skipped

## Test plan

- [ ] CI green
- [ ] Codecov reports 100% on memlimit.ts