### PR TITLE
test: restore 100% coverage on root src/ (errors.ts + pool.ts defensive guards)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -174,6 +174,8 @@ function getErrorMessage(errno: number): string {
     return `Unknown LZMA error code: ${errno}`;
   }
   const msg = messages[errno];
+  /* v8 ignore start: defensive after bounds check on L172 — errno always in [0, messages.length) here */
   if (msg === undefined) return `Unknown LZMA error code: ${errno}`;
+  /* v8 ignore stop */
   return msg;
 }

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -165,6 +165,7 @@ export class LZMAPool extends EventEmitter {
     }
 
     const item = this.queue.shift();
+    /* v8 ignore start: defensive after queue.length > 0 guard on L163 — shift() always returns a value here */
     if (item === undefined) {
       // The `this.queue.length === 0` early-return guard above means shift()
       // must return a value here. Returning silently would let queued tasks
@@ -172,6 +173,7 @@ export class LZMAPool extends EventEmitter {
       // Throw so the bug surfaces at the breach instead of as a hung pool.
       throw new Error('Invariant violation: queue was non-empty but shift() returned undefined');
     }
+    /* v8 ignore stop */
 
     this.metrics.active++;
     this.metrics.queued = this.queue.length;


### PR DESCRIPTION
## Summary

Wrap two defensive branches with `v8 ignore start/stop` to restore root src/ to 100% coverage. Both are intentional fail-closed safety nets that TypeScript's `noUncheckedIndexedAccess` requires (it widens narrowed types) but are unreachable at runtime under current invariants.

### Targets

| File:Line | Code | Prior guard | Why suppression justified |
|-----------|------|-------------|---------------------------|
| `src/errors.ts:176` | `if (msg === undefined) return ...` | L172 bounds check (`errno >= messages.length` early return) | array lookup always returns `string` at runtime ; TS widens type but value is always defined |
| `src/pool.ts:168` | `if (item === undefined) throw ...` | L163 `queue.length === 0` early return | shift() never returns undefined when queue non-empty ; TS widens to `T \| undefined` but value is always `T` |

### Coverage

| Scope | Before | After |
|-------|--------|-------|
| Root `src/` statements | 99.66% (601/603) | **100% (599/599)** |
| Root `src/` branches | 98.97% (194/196) | **100% (192/192)** |
| Root `src/` functions | 100% | **100%** |
| Root `src/` lines | 99.82% (587/588) | **100% (585/585)** |

Combined with PR #121 (packages/nxz 95.2% → 100%), the entire repo is now at 100% coverage.

### Gates

- `pnpm install --frozen-lockfile`: EXIT 0
- `pnpm build`: EXIT 0
- `pnpm type-check`: EXIT 0
- `pnpm exec biome check .`: EXIT 0, 0 warnings
- `pnpm test`: 707 pass / 0 fail / 3 skipped

### Diff

2 files, +4 / -0.

## Test plan

- [ ] CI green
- [ ] Codecov reports 100% repo-wide