### PR TITLE
ci(coverage): upload nxz lcov to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,11 +320,14 @@ jobs:
       - name: Run tar-xz tests with coverage
         run: pnpm --filter tar-xz exec vitest run --coverage
 
+      - name: Run nxz tests with coverage
+        run: pnpm --filter nxz-cli exec vitest run --coverage
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/lcov.info,packages/tar-xz/coverage/lcov.info
+          files: coverage/lcov.info,packages/tar-xz/coverage/lcov.info,packages/nxz/coverage/lcov.info
           flags: unittests
           fail_ci_if_error: false
 

--- a/packages/nxz/package.json
+++ b/packages/nxz/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@biomejs/biome": "catalog:",
     "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/nxz/vitest.config.ts
+++ b/packages/nxz/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      // src/nxz.ts is the CLI entrypoint exercised via execFileSync from cli.test.ts —
+      // vitest workers don't instrument the subprocess, so including it here would
+      // always report 0% on codecov. Track only memlimit.ts (the importable helper
+      // directly imported by parse-memlimit.test.ts).
+      include: ['src/memlimit.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
## Summary

Codecov was missing `packages/nxz/` entirely because the workflow only generated + uploaded coverage for the root + tar-xz packages. This PR adds a per-package coverage step for nxz-cli, registers the new lcov in the Codecov action's files list, and ships the minimal vitest plumbing required.

### Why narrow the coverage `include` to `src/memlimit.ts` only

The nxz CLI entrypoint `src/nxz.ts` is exercised via `execFileSync` from `cli.test.ts` — vitest workers don't instrument the spawned subprocess, so listing `src/nxz.ts` in the coverage `include` would always report 0% on Codecov, hiding the fact that the CLI is end-to-end tested.

`src/memlimit.ts` is the helper directly imported by `parse-memlimit.test.ts` (introduced in PR #117), so it can be measured cleanly. Narrowing `include` keeps the lcov report honest.

### Codex review trail

- **Round 1** : 1 P2 finding caught the gotcha — would have shipped a 0% `src/nxz.ts` regression on Codecov.
- **Fix-round 1** : narrowed `include` from `['src/**/*.ts']` to `['src/memlimit.ts']` + 4-line inline comment explaining the subprocess boundary.
- **Round 2** : CLEAN, 0 findings, ready to merge.

### Diff

4 files, +24/-1 :
- `.github/workflows/ci.yml` (+4/-1)
- `packages/nxz/vitest.config.ts` (NEW, +16)
- `packages/nxz/package.json` (+1)
- `pnpm-lock.yaml` (+3)

### Local repro

`pnpm --filter nxz-cli exec vitest run --coverage` emits `packages/nxz/coverage/lcov.info` with a single `SF:src/memlimit.ts` record at 100%.

### Gates

- `pnpm install --frozen-lockfile` : EXIT 0
- `pnpm type-check` : EXIT 0
- `pnpm exec biome check .` : EXIT 0, 0 warnings
- `pnpm test` : 489 root + 209 tar-xz + 63 nxz = **761 passing**, 0 fail

## Test plan

- [ ] CI green
- [ ] Codecov picks up packages/nxz/src/memlimit.ts at 100%