### PR TITLE
test(tar-xz): close extract.ts coverage partials with v8 ignores

### DIFF
--- a/packages/tar-xz/src/node/extract.ts
+++ b/packages/tar-xz/src/node/extract.ts
@@ -135,7 +135,9 @@ async function drainEntryChunks(
 ): Promise<void> {
   while (true) {
     const result = await parser.next();
+    /* v8 ignore start: parseTar always emits 'end' before returning; this done:true branch is unreachable via the public API */
     if (result.done) return;
+    /* v8 ignore stop */
     if (result.value.kind !== 'chunk') {
       lookaheadRef.value = result.value;
       return;
@@ -193,6 +195,7 @@ function createEntryDataPull(
 ): () => AsyncGenerator<Uint8Array> {
   let dataGenInFlight = false;
   return function makeDataGen(): AsyncGenerator<Uint8Array> {
+    /* v8 ignore start: internal state machine invariant — makeTarEntryWithData() calls dataPull() exactly once per entry and never exposes makeDataGen to consumers; concurrent-iteration path is unreachable via public API */
     if (dataGenInFlight) {
       // D-5 invariant violation: triggered if the same entry's data generator
       // is created twice (`makeDataGen()` called more than once for one
@@ -202,7 +205,6 @@ function createEntryDataPull(
       // `code: 'TAR_PARSER_INVARIANT'` attribute matches the convention used
       // by other invariant errors in this module (e.g. stray-chunk in extract,
       // size-mismatch in bytes()) and keeps downstream filters consistent.
-      /* v8 ignore start: internal state machine invariant — makeTarEntryWithData() calls dataPull() exactly once per entry and never exposes makeDataGen to consumers; concurrent-iteration path is unreachable via public API */
       const err = new Error('concurrent entry.data iteration is not supported') as Error & {
         code?: string;
       };
@@ -215,7 +217,9 @@ function createEntryDataPull(
       try {
         while (true) {
           const r = await parser.next();
+          /* v8 ignore start: parseTar always emits 'end' before returning; this done:true branch is unreachable via the public API */
           if (r.done) return;
+          /* v8 ignore stop */
           if (r.value.kind === 'chunk') {
             yield r.value.data;
           } else {
@@ -290,13 +294,15 @@ export async function* extract(
   try {
     while (true) {
       const result = await nextParseEvent(parser, lookaheadRef);
+      /* v8 ignore start: parseTar always emits 'end' before returning; this done:true branch is unreachable via the public API */
       if (result.done) break;
+      /* v8 ignore stop */
       const ev = result.value;
 
       if (ev.kind === 'end') break;
+      /* v8 ignore start: state machine invariant — parseTar never emits 'chunk' before 'entry'; this branch guards against a hypothetical parser bug that cannot be triggered via the public API */
       if (ev.kind === 'chunk') {
         // Stray chunk at outer-loop level is a parser invariant violation (D-5).
-        /* v8 ignore start: state machine invariant — parseTar never emits 'chunk' before 'entry'; this branch guards against a hypothetical parser bug that cannot be triggered via the public API */
         const err = new Error('parser invariant: chunk emitted before entry');
         (err as Error & { code: string }).code = 'TAR_PARSER_INVARIANT';
         throw err;


### PR DESCRIPTION
## Summary

Close 5 defensive-unreachable branches in `packages/tar-xz/src/node/extract.ts` by wrapping impossible parser states with `v8 ignore start/stop` markers:

- `drainEntryChunks`: `done:true` guard (parseTar always emits `'end'` first)
- `createEntryDataPull`: `dataGenInFlight` condition guard (existing wrap relocated up to cover the if-condition itself)
- `makeDataGen`: `done:true` guard (same parseTar invariant)
- `extract` outer loop: `done:true` guard (same parseTar invariant)
- `extract`: `ev.kind === 'chunk'` condition guard (existing wrap relocated up)

The 5 branches are defensive guards for parser states that cannot occur via the public API: `parseTar` either yields `{kind:'end'}` then returns (line 271-272 of `tar-parser.ts`), or throws `'Unexpected end of archive'` on truncation. A stray `'chunk'` before `'entry'` would be a parser bug. Senior pre-push review confirmed the invariant claim on all 5 wraps.

No tests added — project convention is `v8 ignore start/stop` for defensive-unreachable branches rather than adversarial mocking (mocking external systems is forbidden by `CLAUDE.md`).

**Coverage**: extract.ts 93.75% → 100% lines, 5 → 0 partials. Diff is +8 -2.

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Codecov reports `extract.ts` at 100% lines / 0 partials post-merge
- [ ] No regressions on `packages/tar-xz/test/` (208 tests should still pass)
