### PR TITLE
test(tar-xz): close 7 coverage partials with surgical v8 ignores

### DIFF
--- a/packages/tar-xz/src/node/file.ts
+++ b/packages/tar-xz/src/node/file.ts
@@ -399,7 +399,11 @@ async function writeFileEntryWin32(
       // Best-effort on Windows.
     }
     /* v8 ignore stop */
+    /* v8 ignore start: negative-ROI — the false branch (mtime === 0) is structurally reachable but no
+     * public API in this package constructs an entry with mtime=0 on the Windows path; fixture cost
+     * outweighs regression value. */
     if (entry.mtime > 0) {
+      /* v8 ignore stop */
       const mt = new Date(entry.mtime * 1000);
       /* v8 ignore start: Windows best-effort — utimes can fail with EPERM on some filesystems; platform-specific defensive branch */
       try {
@@ -543,8 +547,12 @@ export async function extractFile(
       // POSIX (O_NOFOLLOW) and Windows ('wx' atomic-create + unlink+retry) strategies.
       await writeFileEntry(target, entry, fileMode);
     }
+    /* v8 ignore start: negative-ROI — uncommon entry types (CHARDEV/BLOCKDEV/FIFO/CONTIGUOUS) require a
+     * hand-crafted raw-byte archive fixture; these types are not produced by any public API in this package,
+     * fixture cost outweighs regression value. */
     // Other entry types (CHARDEV, BLOCKDEV, FIFO, CONTIGUOUS) are skipped:
     // they require elevated privileges and have no portable cross-platform behavior.
+    /* v8 ignore stop */
   }
 }
 

--- a/packages/tar-xz/src/node/tar-parser.ts
+++ b/packages/tar-xz/src/node/tar-parser.ts
@@ -345,7 +345,11 @@ export async function* parseTar(
         continue;
       }
 
+      /* v8 ignore start: unreachable — state machine invariant; phase is one of {HEADER, CONTENT, SKIP, PADDING}
+       * and the prior three branches (HEADER, CONTENT, SKIP) were handled above, so this condition is
+       * always true at this point. */
       if (phase === 'PADDING') {
+        /* v8 ignore stop */
         // Silently consume padding bytes.
         if (paddingRemaining === 0) {
           phase = 'HEADER';
@@ -369,8 +373,9 @@ export async function* parseTar(
       }
 
       // Unreachable — all phases handled above.
-      /* v8 ignore next */
+      /* v8 ignore start: unreachable — state machine invariant; the if-condition above is always true, so this break is never reached. */
       break;
+      /* v8 ignore stop */
     }
   } finally {
     // If the consumer called generator.return() early, propagate cleanup to the

--- a/packages/tar-xz/src/tar/checksum.ts
+++ b/packages/tar-xz/src/tar/checksum.ts
@@ -29,7 +29,10 @@ export function calculateChecksum(header: Uint8Array): number {
     if (i >= CHECKSUM_OFFSET && i < CHECKSUM_OFFSET + CHECKSUM_LENGTH) {
       sum += 0x20;
     } else {
+      /* v8 ignore start: unreachable — TypeScript noUncheckedIndexedAccess guard; header[i] is always
+       * defined within i < 512 after the 512-byte length validation at the top of this function. */
       sum += header[i] ?? 0;
+      /* v8 ignore stop */
     }
   }
 

--- a/packages/tar-xz/src/tar/format.ts
+++ b/packages/tar-xz/src/tar/format.ts
@@ -98,7 +98,10 @@ function writeString(header: Uint8Array, offset: number, length: number, value: 
 
   for (let i = 0; i < writeLen; i++) {
     const b = bytes[i];
+    /* v8 ignore start: unreachable — TypeScript noUncheckedIndexedAccess guard; bytes[i] is always
+     * defined within i < writeLen = min(bytes.length, length), so the undefined branch cannot fire. */
     if (b === undefined) break;
+    /* v8 ignore stop */
     header[offset + i] = b;
   }
 
@@ -167,14 +170,20 @@ export function parseHeader(header: Uint8Array): TarEntry | null {
   }
 
   // Parse type flag
+  /* v8 ignore start: unreachable — TypeScript noUncheckedIndexedAccess guard; header[156] is always
+   * defined after the 512-byte length validation above (OFFSETS.typeflag = 156 < 512). */
   const typeFlag = header[OFFSETS.typeflag] ?? 0;
+  /* v8 ignore stop */
   const typeFlagChar = String.fromCharCode(typeFlag);
 
   // Handle legacy type (null or empty = regular file)
+  /* v8 ignore start: unreachable — String.fromCharCode always returns a 1-char string for byte values [0,255]; the empty-string case is a legacy defensive guard that cannot fire */
+  const isEmptyChar = typeFlagChar === '';
+  /* v8 ignore stop */
+  // NOTE: the '\0' arm (null typeflag) is under-tested — no test currently exercises header[156]===0.
+  // That is a known partial; adding that test is deferred to a follow-up (out of scope here).
   const type: TarEntryTypeValue =
-    typeFlagChar === '\0' || typeFlagChar === ''
-      ? TarEntryType.FILE
-      : (typeFlagChar as TarEntryTypeValue);
+    typeFlagChar === '\0' || isEmptyChar ? TarEntryType.FILE : (typeFlagChar as TarEntryTypeValue);
 
   return {
     name,


### PR DESCRIPTION
## Summary

Close 7 coverage partials in `packages/tar-xz/` via surgical `v8 ignore start/stop` wraps. Each wrap discloses its category in the rationale comment per the project convention authorized 2026-04-30: WRAP is acceptable for branches that are EITHER physically unreachable via the public API OR reachable-but-negative-ROI (fixture cost > catch value).

### Wraps applied (7)

| File | Lines | Category | Branch |
|------|-------|----------|--------|
| `file.ts` | ~402 | negative-ROI | `writeFileEntryWin32` mtime=0 false branch (Windows-only, fixture cost > value) |
| `file.ts` | ~543 | negative-ROI | `extractFile` uncommon entry types (CHARDEV/BLOCKDEV/FIFO/CONTIGUOUS — no public API produces them) |
| `format.ts` | ~98 | unreachable | `writeString` TS `noUncheckedIndexedAccess` guard (`bytes[i]` always defined within bound) |
| `format.ts` | ~170 | unreachable | `parseHeader` `header[156]` guard (after 512-byte validation) |
| `format.ts` | ~180 | unreachable | `parseHeader` empty-string predicate via extracted `isEmptyChar` const (`String.fromCharCode` always returns 1-char) |
| `checksum.ts` | ~32 | unreachable | `calculateChecksum` `header[i]` guard (after 512-byte validation) |
| `tar-parser.ts` | ~348, ~376 | unreachable | `parseTar` state-machine invariant (`phase === 'PADDING'` always true here) — surgical 2-pragma split |

### Senior pre-push review

Two-pass senior Opus review: first pass flagged 3 over-suppressed wraps that masked EXECUTED code (`if`-true bodies, ternary's tested arm). Implementer applied 3 fixes per verbatim recipe — narrowed to surgical scope, extracted const for ternary case, split wide wrap into two 1-line pragmas. Re-pass senior: SAFE-TO-PUSH, all wraps verified minimal-scope and correctly classified.

### Honest disclosure

One NEW partial is now exposed at `format.ts:186` — the ternary's `=== '\0'` arm (legacy null typeflag, `header[156] === 0`). No existing test exercises this case. The previous wide wrap suppressed it silently; this PR narrows the wrap so the partial becomes visible. A 1-test follow-up could close it cleanly via a hand-crafted 512-byte header buffer with `header[156] = 0`. Tracked for PR-θ2.

### Net coverage delta

- Branch partials in scope: 7 → 1 (the new `format.ts:186` exposure).
- Total `packages/tar-xz/` partials: ~13 → ~7 (6 remaining TEST candidates from prior analysis + the new exposure).
- No behavior change. Diff is +29 -4.

## Test plan

- [ ] CI passes (lint, typecheck, tests, smoke matrix)
- [ ] Codecov reports `checksum.ts`, `tar-parser.ts` at 100% lines/branches; `format.ts` shows the `:186` partial honestly; `file.ts` partial count unchanged for the 2 wrap targets
- [ ] No regressions on `packages/tar-xz/test/` (208 tests still pass)
