### PR TITLE
chore(deps): bump release-it-preset to 1.0.0-rc.0 and align Node CI

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Use node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           architecture: ${{ matrix.arch }}
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml

--- a/.github/workflows/check-xz-updates.yml
+++ b/.github/workflows/check-xz-updates.yml
@@ -74,7 +74,7 @@ jobs:
         if: steps.check.outputs.new_version == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Test with latest XZ version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ permissions:
 env:
   # Global environment variables
   NODE_OPTIONS: '--max-old-space-size=4096'
-  NODE_VERSION: '22'
+  NODE_VERSION: '24'
 
 jobs:
   # Determine what to run based on trigger and changes
@@ -340,7 +340,7 @@ jobs:
       fail-fast: true  # Fail fast on smoke tests to save CI minutes
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [22]
+        node: [24]
         runtime_link: [static]
         use_global_liblzma: [false]
         enable_threads: [no]
@@ -512,7 +512,7 @@ jobs:
       matrix:
         # Threading tests only on Unix platforms (Windows threading tested in full-test)
         os: [ubuntu-latest, macos-latest]
-        node: [22]  # Latest Node only for threading tests
+        node: [24]  # Latest Node only for threading tests
         config:
           - {runtime_link: "static", use_global_liblzma: false, enable_threads: "yes"}
           - {runtime_link: "shared", use_global_liblzma: false, enable_threads: "yes"}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.language == 'javascript-typescript' || matrix.language == 'c-cpp'
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Setup Python (for XZ download)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Cache XZ sources
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Regenerate lockfile
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '24'
 
 jobs:
   release:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
-    "@oorabona/release-it-preset": "^0.12.0",
+    "@oorabona/release-it-preset": "^1.0.0-rc.0",
     "@oorabona/vitest-monocart-coverage": "^2.0.1",
     "@types/node": "catalog:",
     "@vitest/coverage-istanbul": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 'catalog:'
         version: 2.4.13
       '@oorabona/release-it-preset':
-        specifier: ^0.12.0
-        version: 0.12.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))
+        specifier: ^1.0.0-rc.0
+        version: 1.0.0-rc.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))
       '@oorabona/vitest-monocart-coverage':
         specifier: ^2.0.1
         version: 2.0.1(vitest@4.1.5)
@@ -501,12 +501,12 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oorabona/release-it-preset@0.12.0':
-    resolution: {integrity: sha512-OrX1rxl8JIN34bqYFdHuxOf/FjfgE67vyNJaGFicgW0H7MSNv0+uOqHNnc3FtdFndOkFWbclLdKEqn3Vm8Sq8w==}
-    engines: {node: '>=18.0.0'}
+  '@oorabona/release-it-preset@1.0.0-rc.0':
+    resolution: {integrity: sha512-y1D5N62VoIrszcZftJZoywAGfTVkw6bGAd83Ktb+QOf+A2a0Azz86JeYaoi5F/GTJf9eLsHzxQs2tUQtEo/smQ==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
-      release-it: ^20.0.0
+      release-it: ^19.0.0 || ^20.0.0
 
   '@oorabona/vitest-monocart-coverage@2.0.1':
     resolution: {integrity: sha512-Z6eE1Q64hz4qCm0LEQIUT9UJG12qerU6JtnUihZyPOdVzgL74kVOzjFtSPVGt05smwmmFkHNaJZcs25J9yOnEQ==}
@@ -2524,7 +2524,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oorabona/release-it-preset@0.12.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))':
+  '@oorabona/release-it-preset@1.0.0-rc.0(release-it@20.0.1(@types/node@25.6.0)(magicast@0.5.2))':
     dependencies:
       release-it: 20.0.1(@types/node@25.6.0)(magicast@0.5.2)
 


### PR DESCRIPTION
## Summary

Coherent release-tooling stack alignment:

1. **Bump `@oorabona/release-it-preset`** from `^0.12.0` to `^1.0.0-rc.0`
   - Tracks the RC train AND the eventual `1.0.0` final via the caret
   - Peer dep range `release-it ^19 || ^20` is satisfied by repo's `release-it ^20.0.0`
   - Smoke test via the new `release-it-preset doctor` command (introduced in 0.15) — passes Environment + Repository + Configuration + Readiness sections; only expected warns on a feature branch (dirty tree, empty `[Unreleased]` section).

2. **Align 8 GitHub Actions workflows on Node 24** (was 22, except `publish.yml` which was already 24 for npm OIDC):
   - `release.yml`, `pre-release.yml`, `ci.yml` (env), `docs.yml`, `check-xz-updates.yml`, `refresh-lockfile.yml`, `codeql.yml`, `build-artifacts.yml`
   - Multi-version test matrices **preserved intact**:
     - `ci.yml` full matrix `node: ['22', '24']`
     - `pre-release.yml` matrix `node: [22, 24]`
   - Smoke and threading single-Node matrices in `ci.yml` bumped from `[22]` to `[24]` (the threading job's `# Latest Node only` comment was already in place; updating the version makes it accurate again).

### Why same PR

The Node alignment is a follow-on hardening of the release-tooling stack: the preset's recommended runtime evolves with each RC, and keeping CI base + release-tooling base in lockstep on a single primary Node version reduces drift between local dev, CI, and the publish/release jobs.

### Net diff

- 10 files changed: `package.json` (+1 -1), `pnpm-lock.yaml` (+7 -7), 8 workflow files (+11 -11)
- **No source code touched, no test changes, no behavior changes.**

### Why integrate the RC

User is the maintainer of `release-it-preset`. node-liblzma is the natural test bed for the RC ahead of the 1.0 stable release — surfaces real-world issues before final ship.

## Test plan

- [ ] CI passes on this PR (lint, typecheck, build, full test matrix on Node 22 + 24)
- [ ] Smoke matrix on macOS / Windows / Linux Node 24 passes (was previously running on Node 22)
- [ ] Codecov stays at 100% (the prior session-batch outcome) — no regressions from Node version bump
- [ ] `pnpm install` resolves cleanly with no peer-dep warnings on the `@oorabona/release-it-preset` resolution
