### PR TITLE
docs(pages): add tar-xz API and nxz CLI to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,8 +70,7 @@ jobs:
         run: pnpm typedoc
 
       - name: Build tar-xz API docs
-        working-directory: packages/tar-xz
-        run: pnpm exec typedoc
+        run: pnpm exec typedoc --options packages/tar-xz/typedoc.json
 
       - name: Copy llms.txt to docs site
         run: cp llms.txt docs-site/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
       - 'llms.txt'
       - 'examples/browser/**'
       - 'packages/tar-xz/**'
+      - 'packages/nxz/**'
       - 'src/wasm/**'
   workflow_dispatch:
 
@@ -67,6 +68,10 @@ jobs:
 
       - name: Build documentation
         run: pnpm typedoc
+
+      - name: Build tar-xz API docs
+        working-directory: packages/tar-xz
+        run: pnpm exec typedoc
 
       - name: Copy llms.txt to docs site
         run: cp llms.txt docs-site/

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@ _None._
 ## Pending - LOW (Nice to Have)
 
 - [ ] [Release] Consider `engines.node` bump from `>=22.0.0` to `>=22.13.0` when 22.0–22.12 usage drops — surfaced by Copilot round 2 on PR #116 ; deferred because library itself runs fine on 22.0+, the 22.13 floor only applies to the dev/release toolchain (release-it@20). Re-evaluate if anyone reports install warnings.
+- [ ] [nxz] Fix misleading example in `nxz --help` output — surfaced by Copilot round 3 on PR #133 (docs). The example `nxz -T -z dir/            create archive.tar.xz from dir/` claims output filename `archive.tar.xz` but the CLI actually derives `dir.tar.xz` from the input. Update the help text source in `packages/nxz/src/nxz.ts` to match real behavior, then sync `docs/nxz-usage.md`. Doc was corrected pre-emptively in PR #133, so docs are accurate but currently diverge from `--help` output until CLI source is updated.
 <!-- F-002 (HARDLINK + undefined linkname → TypeError) DROPPED 2026-04-29 by Copilot round-2 review on PR #115: TarEntry.linkname is typed as required string (parser returns '' for empty fields), and ensureSafeLinkname → ensureSafeName already rejects '' with "empty linkname" before reaching resolve(). The original concern was mischaracterized — there is no path where resolve(cwd, undefined) gets called with undefined. -->
 
 

--- a/docs/nxz-usage.md
+++ b/docs/nxz-usage.md
@@ -64,7 +64,7 @@ With no FILE, or when FILE is -, read standard input.
 Examples:
   nxz file.txt              compress file.txt to file.txt.xz
   nxz -d file.xz            decompress file.xz
-  nxz -T -z dir/            create archive.tar.xz from dir/
+  nxz -T -z dir/            create dir.tar.xz from dir/
   nxz -l archive.tar.xz     list contents of archive
   nxz -d archive.tar.xz     extract archive to current directory
   nxz -d -o dest/ arch.txz  extract archive to dest/

--- a/docs/nxz-usage.md
+++ b/docs/nxz-usage.md
@@ -14,8 +14,8 @@ npm install -g nxz-cli
 # pnpm
 pnpm add -g nxz-cli
 
-# Run without installing
-npx nxz-cli --help
+# Run without installing (binary name is `nxz`, package name is `nxz-cli`)
+npx --package nxz-cli nxz --help
 ```
 
 ## Usage

--- a/docs/nxz-usage.md
+++ b/docs/nxz-usage.md
@@ -1,0 +1,131 @@
+# nxz CLI
+
+`nxz` is a portable, Node.js-powered XZ compression CLI — a drop-in alternative to the
+system `xz` utility that also handles `.tar.xz` archives.
+It is published as [`nxz-cli`](https://www.npmjs.com/package/nxz-cli) on npm and backed by
+[node-liblzma](https://github.com/oorabona/node-liblzma).
+
+## Install
+
+```bash
+# npm
+npm install -g nxz-cli
+
+# pnpm
+pnpm add -g nxz-cli
+
+# Run without installing
+npx nxz-cli --help
+```
+
+## Usage
+
+```
+nxz - Node.js XZ compression CLI (using node-liblzma)
+
+Usage: nxz [OPTION]... [FILE]...
+
+Compress or decompress FILEs in the .xz format.
+
+Operation mode:
+  -z, --compress    force compression
+  -d, --decompress  force decompression
+  -l, --list        list information about .xz files
+  -B, --benchmark   benchmark native vs WASM compression
+
+Archive mode (tar.xz):
+  -T, --tar         treat file as tar.xz archive
+                    Auto-detected for .tar.xz and .txz files
+  --strip=N         strip N leading path components on extract (default: 0)
+
+Operation modifiers:
+  -k, --keep        keep (don't delete) input files
+  -f, --force       force overwrite of output file
+  -c, --stdout      write to standard output and don't delete input files
+  -o, --output=FILE write output to FILE (or directory for tar extract)
+  --memlimit-decompress=SIZE
+                    limit decompressor memory usage (e.g. 256MiB, 1GiB, 512KB,
+                    268435456); use 0 or max for no limit
+                    (IEC suffixes 1024-based, SI suffixes 1000-based,
+                    integer mantissa only)
+
+Compression presets:
+  -0 ... -9         compression preset level (default: 6)
+  -e, --extreme     use extreme compression (slower)
+
+Other options:
+  -v, --verbose     be verbose (show progress)
+  -q, --quiet       suppress warnings
+  -h, --help        display this help and exit
+  -V, --version     display version information and exit
+
+With no FILE, or when FILE is -, read standard input.
+
+Examples:
+  nxz file.txt              compress file.txt to file.txt.xz
+  nxz -d file.xz            decompress file.xz
+  nxz -T -z dir/            create archive.tar.xz from dir/
+  nxz -l archive.tar.xz     list contents of archive
+  nxz -d archive.tar.xz     extract archive to current directory
+  nxz -d -o dest/ arch.txz  extract archive to dest/
+
+Report bugs at: https://github.com/oorabona/node-liblzma/issues
+```
+
+## Common examples
+
+### Compress a file
+
+```bash
+nxz file.txt          # produces file.txt.xz, removes file.txt
+nxz -k file.txt       # keep the original
+nxz -9e file.txt      # maximum compression (level 9 + extreme)
+```
+
+### Decompress a file
+
+```bash
+nxz -d file.txt.xz
+nxz -d -k file.txt.xz   # keep the .xz file
+```
+
+### Create a .tar.xz archive
+
+```bash
+# Archive a directory
+nxz -T src/ lib/ -o project.tar.xz
+
+# Or pipe via stdout
+nxz -T -c src/ > src.tar.xz
+```
+
+### List archive contents
+
+```bash
+nxz -l archive.tar.xz
+```
+
+### Extract a .tar.xz archive
+
+```bash
+nxz -d archive.tar.xz              # extract to current directory
+nxz -d archive.tar.xz -o dest/     # extract to dest/
+nxz -d archive.tar.xz --strip=1    # strip one leading path component
+```
+
+### Memory-constrained decompression
+
+```bash
+nxz -d --memlimit-decompress=128MiB large.xz
+nxz -d --memlimit-decompress=0 huge.xz      # no limit
+```
+
+### Benchmark native vs WASM
+
+```bash
+nxz -B file.txt
+```
+
+## Source
+
+[github.com/oorabona/node-liblzma/tree/master/packages/nxz](https://github.com/oorabona/node-liblzma/tree/master/packages/nxz)

--- a/packages/tar-xz/typedoc.json
+++ b/packages/tar-xz/typedoc.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/lzma.ts", "src/errors.ts", "src/pool.ts", "src/types.ts"],
-  "out": "docs-site",
-  "name": "node-liblzma",
+  "entryPoints": ["src/index.ts", "src/node/file.ts"],
+  "out": "../../docs-site/tar-xz-api",
+  "name": "tar-xz",
   "readme": "README.md",
   "includeVersion": true,
   "excludePrivate": true,
   "excludeProtected": true,
   "excludeInternal": true,
   "excludeExternals": true,
-  "projectDocuments": ["docs/nxz-usage.md"],
   "navigationLinks": {
-    "GitHub": "https://github.com/oorabona/node-liblzma",
-    "npm": "https://www.npmjs.com/package/node-liblzma",
-    "tar-xz API": "tar-xz-api/"
+    "GitHub": "https://github.com/oorabona/node-liblzma/tree/master/packages/tar-xz",
+    "npm": "https://www.npmjs.com/package/tar-xz",
+    "Demo": "../tar-xz/",
+    "node-liblzma API": "../"
   },
   "plugin": ["typedoc-material-theme"],
   "hideGenerator": true,

--- a/packages/tar-xz/typedoc.json
+++ b/packages/tar-xz/typedoc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts", "src/node/file.ts"],
+  "tsconfig": "./tsconfig.json",
   "out": "../../docs-site/tar-xz-api",
   "name": "tar-xz",
   "readme": "README.md",


### PR DESCRIPTION
## Summary

Extend the GitHub Pages site to cover the two workspace packages that were previously invisible:

- **`tar-xz` API documentation** (NEW) at `docs-site/tar-xz-api/` — typedoc-generated reference for `TarPack` / `TarUnpack` / `TarList`, `extractFile`, `pack`, helpers, types.
- **`nxz` CLI usage guide** (NEW) at `docs-site/documents/nxz-usage.html` — install, full `--help` output, common examples, source link. Rendered via typedoc's native `projectDocuments` feature (typedoc 0.27+).

The browser demo at `docs-site/tar-xz/` (built by vite) is preserved unchanged — no path collision.

### Changes

| File | Type | Purpose |
|------|------|---------|
| `typedoc.json` | modified | Add `projectDocuments` for nxz, `navigationLinks["tar-xz API"]` |
| `packages/tar-xz/typedoc.json` | NEW | Per-package typedoc config (entry points, output to `../../docs-site/tar-xz-api`, cross-links to demo + root) |
| `docs/nxz-usage.md` | NEW | 131-line CLI usage page |
| `.github/workflows/docs.yml` | modified | Add `packages/nxz/**` to paths trigger; add "Build tar-xz API docs" step |

Local verification: `pnpm typedoc` (root) + `pnpm exec typedoc` (in `packages/tar-xz/`) both build clean. 2 pre-existing warnings (`@security` JSDoc tag, unexported `TarEntryTypeValue`) are not introduced by this PR.

### Why this PR

GitHub Pages previously documented only the root `node-liblzma` package. Both `tar-xz` (npm: `tar-xz`) and `nxz-cli` (npm: `nxz-cli`) are independently published packages with public surfaces deserving documentation. This closes that gap.

## Test plan

- [ ] CI passes on this PR (lint, typecheck, build)
- [ ] On merge, `docs.yml` workflow successfully rebuilds + deploys all three documentation surfaces
- [ ] `oorabona.github.io/node-liblzma/` post-deploy: nav has working "tar-xz API" link to `tar-xz-api/`, sidebar has `nxz-usage` document
- [ ] `tar-xz-api/` page has cross-links back to demo + root API
- [ ] No regression on existing root API docs or demo
