### PR TITLE
refactor(nxz)!: rename nxz-cli to nxz and bump to 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
         run: pnpm --filter tar-xz exec vitest run --coverage
 
       - name: Run nxz tests with coverage
-        run: pnpm --filter nxz-cli exec vitest run --coverage
+        run: pnpm --filter nxz exec vitest run --coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 # Publishes exactly one package per run, determined by target_package.
 # - node-liblzma: checkout by tag, download prebuilds, build WASM, publish root
 # - tar-xz:       checkout master HEAD, build TS, publish packages/tar-xz
-# - nxz-cli:      checkout master HEAD, build TS, publish packages/nxz
+# - nxz:          checkout master HEAD, build TS, publish packages/nxz
 #
 # Each package manages its own version; there is no cross-package version sync.
 
@@ -42,7 +42,7 @@ on:
         options:
           - node-liblzma
           - tar-xz
-          - nxz-cli
+          - nxz
       skip_npm:
         description: 'Skip npm publish (for testing)'
         type: boolean
@@ -220,8 +220,8 @@ jobs:
             npm publish "${TARBALL_PATH}" --provenance --access public $TAG_FLAG
           fi
 
-      - name: Publish nxz-cli to npm with provenance
-        if: inputs.target_package == 'nxz-cli' && inputs.skip_npm != true
+      - name: Publish nxz to npm with provenance
+        if: inputs.target_package == 'nxz' && inputs.skip_npm != true
         env:
           NPM_TAG: ${{ inputs.npm_tag }}
           PKG_DIR: packages/nxz
@@ -263,8 +263,8 @@ jobs:
               VERSION=$(node -p "require('./packages/tar-xz/package.json').version")
               echo "- tar-xz@${VERSION}" >> "$GITHUB_STEP_SUMMARY"
               ;;
-            nxz-cli)
+            nxz)
               VERSION=$(node -p "require('./packages/nxz/package.json').version")
-              echo "- nxz-cli@${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+              echo "- nxz@${VERSION}" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # Supports independent versioning for each workspace package.
 # - node-liblzma: full flow (bump root, GPG-signed tag, GitHub Release, prebuilds, npm publish)
-# - tar-xz / nxz-cli: lightweight flow (bump workspace package.json, CHANGELOG commit, npm publish; no tag, no prebuilds)
+# - tar-xz / nxz:     lightweight flow (bump workspace package.json, CHANGELOG commit, npm publish; no tag, no prebuilds)
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ on:
         options:
           - node-liblzma
           - tar-xz
-          - nxz-cli
+          - nxz
       skip_npm:
         description: 'Skip npm publish (dry run)'
         type: boolean
@@ -95,7 +95,7 @@ jobs:
             --ci --increment "$INCREMENT"
 
       # ── workspace packages: bump the sub-package's package.json ────────────
-      - name: Bump workspace version and update CHANGELOG (tar-xz or nxz-cli)
+      - name: Bump workspace version and update CHANGELOG (tar-xz or nxz)
         if: inputs.target_package != 'node-liblzma'
         env:
           INCREMENT: ${{ inputs.increment }}

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ Archives created by nxz are fully compatible with system `tar -xJf`.
 <summary><strong>One-shot usage (without global install)</strong></summary>
 
 ```bash
-# Standalone nxz-cli package (recommended — smaller, faster install)
-npx nxz-cli --help
-pnpm dlx nxz-cli --help
+# Standalone nxz package (recommended — smaller, faster install)
+npx nxz --help
+pnpm dlx nxz --help
 
 # Or via the full node-liblzma package
 npx --package node-liblzma nxz --help
@@ -369,7 +369,7 @@ node-liblzma powers a family of focused packages:
 |---------|-------------|---------|
 | [`node-liblzma`](https://www.npmjs.com/package/node-liblzma) | Core XZ library — Node.js native + browser WASM | `npm i node-liblzma` |
 | [`tar-xz`](https://www.npmjs.com/package/tar-xz) | Create/extract .tar.xz archives — stream-first, Node + browser, same API (v6) | `npm i tar-xz` |
-| [`nxz-cli`](https://www.npmjs.com/package/nxz-cli) | Standalone CLI — `npx nxz-cli file.txt` | `npx nxz-cli` |
+| [`nxz`](https://www.npmjs.com/package/nxz) | Standalone CLI — `npx nxz file.txt` | `npx nxz` |
 
 ### tar-xz — tar.xz archives (v6)
 
@@ -411,18 +411,18 @@ await extractFile('archive.tar.xz', { cwd: './output', strip: 1 });
 const entries = await listFile('archive.tar.xz');
 ```
 
-### nxz-cli — standalone CLI
+### nxz — standalone CLI
 
 A lightweight wrapper package for running `nxz` without installing the full `node-liblzma`:
 
 ```bash
 # No install needed
-npx nxz-cli file.txt              # compress
-npx nxz-cli -d file.txt.xz        # decompress
-npx nxz-cli -T src/ -o app.tar.xz # create tar.xz archive
+npx nxz file.txt              # compress
+npx nxz -d file.txt.xz        # decompress
+npx nxz -T src/ -o app.tar.xz # create tar.xz archive
 
 # Or install globally
-npm install -g nxz-cli
+npm install -g nxz
 ```
 
 ## API Reference
@@ -885,7 +885,7 @@ npm config set python python3
 ## Related Projects
 
 - [tar-xz](https://www.npmjs.com/package/tar-xz) — Create/extract tar.xz archives (powered by node-liblzma)
-- [nxz-cli](https://www.npmjs.com/package/nxz-cli) — Standalone CLI for XZ compression
+- [nxz](https://www.npmjs.com/package/nxz) — Standalone CLI for XZ compression
 - [lzma-purejs](https://github.com/cscott/lzma-purejs) — Pure JavaScript LZMA implementation
 - [node-xz](https://github.com/robey/node-xz) — Node binding of XZ library
 - [lzma-native](https://github.com/addaleax/lzma-native) — Complete XZ library bindings

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ _None._
 - [x] ✅ [WASM] PR #111 Round 2 Copilot fixes — C-2-001 TSDoc xzAsync removed from honored-by list, C-2-002 stale lzma.ts comment, C-2-003 LZMA_OPTIONS_ERROR constant replaces magic 8, C-2-004 MAX_SAFE_INTEGER guard + TSDoc, C-2-005 validateMemlimit lifted to decoderInit+autoDecoderInit; 12 new tests, 474+99+27=600 tests pass (2026-04-28)
 - [x] ✅ [WASM] PR #111 Round 1 review fixes — F-001 memlimit validation (NaN/Inf/frac/neg → LZMAOptionsError), F-002 ResolvedLZMAOptions internal type, C-001/C-002 async callback fixture pattern, C-003 byte-equality assertion, F-003 TSDoc reorder, F-004 stale comment, F-005 fixture comment magnitude, F-006 default-path caveat; 4 new tests (12 total in decompress-memlimit.test.ts), 458+99+27=584 tests pass (2026-04-28)
 - [x] ✅ [WASM] Wire `memlimit` through `LZMAOptions` → `unxzAsync`/`unxz` — `LZMAMemoryLimitError` thrown when limit exceeded; 8 new tests in `test/wasm/decompress-memlimit.test.ts`; TSDoc with parity note (2026-04-28)
-- [x] ✅ [Refactor] Rename `nxz-cli` → `nxz` (7.0.0 major bump) — package.json, help text fix, all doc/workflow refs updated — closes PR #<TBD>
+- [x] ✅ [Refactor] Rename `nxz-cli` → `nxz` (7.0.0 major bump) — package.json, help text fix, all doc/workflow refs updated — closes PR #134
 - [x] ✅ [tar-xz v6] Universal stream-first redesign: `create()`/`extract()`/`list()` with `AsyncIterable<Uint8Array>`, identical Node/Browser signatures, `tar-xz/file` subpath for fs helpers — published as `tar-xz@6.0.0` + `nxz-cli@6.0.0` (2026-04-27)
 - [x] ✅ [tar-xz v6] Security hardening: 18 path/symlink TOCTOU vectors audited and closed (leaf check, ENOENT walk, hardlink linkSource, NUL/empty rejection, setuid mask, fd-based fs ops with O_NOFOLLOW, pipeline error propagation) — 8 Copilot review rounds + 1 consolidated audit (2026-04-27)
 - [x] ✅ [Infra] Independent versioning per workspace package: `release.yml`/`publish.yml` accept `target_package` input, no cross-package version sync; proven in prod — `tar-xz@6.0.0` published without bumping `node-liblzma` (still at 5.0.0) (2026-04-27)
@@ -87,7 +87,7 @@ _None_
 | LOW | 1 | engines.node bump consideration (deferred — wait-and-see) |
 
 **Last merge:** PR #120 squash `43c4d25` (2026-04-30) — `refactor(nxz)`: split `parseMemlimitSize` via extract-method (CC 17→2) ; repo now biome-clean.
-**Last release:** `nxz@7.0.0` (rename from `nxz-cli`, major bump, help text fix) — closes PR #<TBD>.
+**Last release:** `nxz-cli@6.1.0` (release commit `ecff028`, npm published 2026-04-30). **Pending:** `nxz@7.0.0` (PR #134 merged; placeholder publish + OIDC config + `nxz-cli` deprecation are manual post-merge steps — see PR #134 description).
 **Last audit:** all post-#117 follow-ups merged (PR #118 preset 0.12.0 ; PR #119 dead biome-ignore removal ; PR #120 parseMemlimitSize CC refactor). Repo is biome-clean (0 warnings) and 707 tests green.
 **Last story arc:** #25 + #26 + 4 follow-ups end-to-end — per-package CHANGELOG scoping (cross-repo) → `--memlimit-decompress` feature → release v6.1.0 → upstream tag-baseline fix consumption → biome cleanup → parser CC refactor. Cross-LLM reviewing pattern (Codex substituted for Copilot quota) rodé.
 
@@ -97,4 +97,4 @@ _None_
 |---------|---------|
 | `node-liblzma` | 5.0.0 |
 | `tar-xz` | 6.1.0 |
-| `nxz` | 7.0.0 |
+| `nxz` | 7.0.0 (pending publish) |

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ _None._
 ## Pending - LOW (Nice to Have)
 
 - [ ] [Release] Consider `engines.node` bump from `>=22.0.0` to `>=22.13.0` when 22.0–22.12 usage drops — surfaced by Copilot round 2 on PR #116 ; deferred because library itself runs fine on 22.0+, the 22.13 floor only applies to the dev/release toolchain (release-it@20). Re-evaluate if anyone reports install warnings.
-- [ ] [nxz] Fix misleading example in `nxz --help` output — surfaced by Copilot round 3 on PR #133 (docs). The example `nxz -T -z dir/            create archive.tar.xz from dir/` claims output filename `archive.tar.xz` but the CLI actually derives `dir.tar.xz` from the input. Update the help text source in `packages/nxz/src/nxz.ts` to match real behavior, then sync `docs/nxz-usage.md`. Doc was corrected pre-emptively in PR #133, so docs are accurate but currently diverge from `--help` output until CLI source is updated.
+- [x] ✅ [nxz] Fix misleading example in `nxz --help` output — surfaced by Copilot round 3 on PR #133 (docs). The example `nxz -T -z dir/            create archive.tar.xz from dir/` claims output filename `archive.tar.xz` but the CLI actually derives `dir.tar.xz` from the input. Fixed in `packages/nxz/src/nxz.ts` (this PR).
 <!-- F-002 (HARDLINK + undefined linkname → TypeError) DROPPED 2026-04-29 by Copilot round-2 review on PR #115: TarEntry.linkname is typed as required string (parser returns '' for empty fields), and ensureSafeLinkname → ensureSafeName already rejects '' with "empty linkname" before reaching resolve(). The original concern was mischaracterized — there is no path where resolve(cwd, undefined) gets called with undefined. -->
 
 
@@ -37,6 +37,7 @@ _None._
 - [x] ✅ [WASM] PR #111 Round 2 Copilot fixes — C-2-001 TSDoc xzAsync removed from honored-by list, C-2-002 stale lzma.ts comment, C-2-003 LZMA_OPTIONS_ERROR constant replaces magic 8, C-2-004 MAX_SAFE_INTEGER guard + TSDoc, C-2-005 validateMemlimit lifted to decoderInit+autoDecoderInit; 12 new tests, 474+99+27=600 tests pass (2026-04-28)
 - [x] ✅ [WASM] PR #111 Round 1 review fixes — F-001 memlimit validation (NaN/Inf/frac/neg → LZMAOptionsError), F-002 ResolvedLZMAOptions internal type, C-001/C-002 async callback fixture pattern, C-003 byte-equality assertion, F-003 TSDoc reorder, F-004 stale comment, F-005 fixture comment magnitude, F-006 default-path caveat; 4 new tests (12 total in decompress-memlimit.test.ts), 458+99+27=584 tests pass (2026-04-28)
 - [x] ✅ [WASM] Wire `memlimit` through `LZMAOptions` → `unxzAsync`/`unxz` — `LZMAMemoryLimitError` thrown when limit exceeded; 8 new tests in `test/wasm/decompress-memlimit.test.ts`; TSDoc with parity note (2026-04-28)
+- [x] ✅ [Refactor] Rename `nxz-cli` → `nxz` (7.0.0 major bump) — package.json, help text fix, all doc/workflow refs updated — closes PR #<TBD>
 - [x] ✅ [tar-xz v6] Universal stream-first redesign: `create()`/`extract()`/`list()` with `AsyncIterable<Uint8Array>`, identical Node/Browser signatures, `tar-xz/file` subpath for fs helpers — published as `tar-xz@6.0.0` + `nxz-cli@6.0.0` (2026-04-27)
 - [x] ✅ [tar-xz v6] Security hardening: 18 path/symlink TOCTOU vectors audited and closed (leaf check, ENOENT walk, hardlink linkSource, NUL/empty rejection, setuid mask, fd-based fs ops with O_NOFOLLOW, pipeline error propagation) — 8 Copilot review rounds + 1 consolidated audit (2026-04-27)
 - [x] ✅ [Infra] Independent versioning per workspace package: `release.yml`/`publish.yml` accept `target_package` input, no cross-package version sync; proven in prod — `tar-xz@6.0.0` published without bumping `node-liblzma` (still at 5.0.0) (2026-04-27)
@@ -86,7 +87,7 @@ _None_
 | LOW | 1 | engines.node bump consideration (deferred — wait-and-see) |
 
 **Last merge:** PR #120 squash `43c4d25` (2026-04-30) — `refactor(nxz)`: split `parseMemlimitSize` via extract-method (CC 17→2) ; repo now biome-clean.
-**Last release:** `nxz-cli@6.1.0` (release commit `ecff028`, npm published 2026-04-30) — first real feature minor since 6.0.0.
+**Last release:** `nxz@7.0.0` (rename from `nxz-cli`, major bump, help text fix) — closes PR #<TBD>.
 **Last audit:** all post-#117 follow-ups merged (PR #118 preset 0.12.0 ; PR #119 dead biome-ignore removal ; PR #120 parseMemlimitSize CC refactor). Repo is biome-clean (0 warnings) and 707 tests green.
 **Last story arc:** #25 + #26 + 4 follow-ups end-to-end — per-package CHANGELOG scoping (cross-repo) → `--memlimit-decompress` feature → release v6.1.0 → upstream tag-baseline fix consumption → biome cleanup → parser CC refactor. Cross-LLM reviewing pattern (Codex substituted for Copilot quota) rodé.
 
@@ -96,4 +97,4 @@ _None_
 |---------|---------|
 | `node-liblzma` | 5.0.0 |
 | `tar-xz` | 6.1.0 |
-| `nxz-cli` | 6.1.0 |
+| `nxz` | 7.0.0 |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,7 +49,7 @@ sequenceDiagram
     R->>P: gh workflow run publish.yml
     P->>NPM: Publish node-liblzma (OIDC)
     P->>NPM: Publish tar-xz (OIDC)
-    P->>NPM: Publish nxz-cli (OIDC)
+    P->>NPM: Publish nxz (OIDC)
 ```
 
 ### Inputs
@@ -140,7 +140,7 @@ Three packages are published in dependency order:
 |---|---------|----------|-------------|
 | 1 | root | `node-liblzma` | Core XZ/LZMA2 bindings (native + WASM) |
 | 2 | packages/tar-xz | `tar-xz` | tar.xz streaming library |
-| 3 | packages/nxz | `nxz-cli` | CLI tool for XZ compression |
+| 3 | packages/nxz | `nxz` | CLI tool for XZ compression |
 
 ### Publishing details
 

--- a/docs/nxz-usage.md
+++ b/docs/nxz-usage.md
@@ -2,20 +2,20 @@
 
 `nxz` is a portable, Node.js-powered XZ compression CLI — a drop-in alternative to the
 system `xz` utility that also handles `.tar.xz` archives.
-It is published as [`nxz-cli`](https://www.npmjs.com/package/nxz-cli) on npm and backed by
+It is published as [`nxz`](https://www.npmjs.com/package/nxz) on npm and backed by
 [node-liblzma](https://github.com/oorabona/node-liblzma).
 
 ## Install
 
 ```bash
 # npm
-npm install -g nxz-cli
+npm install -g nxz
 
 # pnpm
-pnpm add -g nxz-cli
+pnpm add -g nxz
 
-# Run without installing (binary name is `nxz`, package name is `nxz-cli`)
-npx --package nxz-cli nxz --help
+# Run without installing
+npx nxz --help
 ```
 
 ## Usage

--- a/packages/nxz/.release-it.json
+++ b/packages/nxz/.release-it.json
@@ -3,7 +3,7 @@
   "git": {
     "requireBranch": "master",
     "requireCleanWorkingDir": true,
-    "commitMessage": "chore(nxz-cli): release v${version}",
+    "commitMessage": "chore(nxz): release v${version}",
     "tagName": null,
     "push": false
   }

--- a/packages/nxz/CHANGELOG.md
+++ b/packages/nxz/CHANGELOG.md
@@ -38,6 +38,7 @@ Internal rewiring to consume the new `tar-xz` v6 API. **No CLI behavior change**
 
 - Updated dependencies (`tar-xz`: `^5.0.0` → `^6.0.0`)
 
-[Unreleased]: https://github.com/oorabona/node-liblzma/compare/v6.1.0...HEAD
+[Unreleased]: https://github.com/oorabona/node-liblzma/compare/v7.0.0...HEAD
+[7.0.0]: https://github.com/oorabona/node-liblzma/compare/v6.1.0...v7.0.0
 [v6.1.0]: https://github.com/oorabona/node-liblzma/releases/tag/v6.1.0
 [6.1.0]: https://github.com/oorabona/node-liblzma/releases/tag/v6.1.0

--- a/packages/nxz/CHANGELOG.md
+++ b/packages/nxz/CHANGELOG.md
@@ -1,6 +1,14 @@
-# nxz-cli
+# nxz
 
 ## [Unreleased]
+
+## [7.0.0] - 2026-04-30
+
+### BREAKING CHANGES
+- Package renamed from `nxz-cli` to `nxz`. Update install commands: `npm i -g nxz` (was `npm i -g nxz-cli`). Binary name unchanged (`nxz`). The old `nxz-cli` package on npm is deprecated with a redirect message; consumers using `npx nxz-cli` should switch to `npx nxz`.
+
+### Fixed
+- CLI `--help` example for `nxz -T -z dir/` now correctly shows `dir.tar.xz` as default output (was previously labeled `archive.tar.xz`).
 
 ## [6.1.0] - 2026-04-30
 

--- a/packages/nxz/CHANGELOG.md
+++ b/packages/nxz/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [7.0.0] - 2026-04-30
 
 ### BREAKING CHANGES
-- Package renamed from `nxz-cli` to `nxz`. Update install commands: `npm i -g nxz` (was `npm i -g nxz-cli`). Binary name unchanged (`nxz`). The old `nxz-cli` package on npm is deprecated with a redirect message; consumers using `npx nxz-cli` should switch to `npx nxz`.
+- Package renamed from `nxz-cli` to `nxz`. Update install commands: `npm i -g nxz` (was `npm i -g nxz-cli`). Binary name unchanged (`nxz`). The old `nxz-cli` package on npm is being deprecated as part of this release with a redirect message; consumers using `npx nxz-cli` should switch to `npx nxz`.
 
 ### Fixed
 - CLI `--help` example for `nxz -T -z dir/` now correctly shows `dir.tar.xz` as default output (was previously labeled `archive.tar.xz`).

--- a/packages/nxz/CHANGELOG.md
+++ b/packages/nxz/CHANGELOG.md
@@ -38,7 +38,6 @@ Internal rewiring to consume the new `tar-xz` v6 API. **No CLI behavior change**
 
 - Updated dependencies (`tar-xz`: `^5.0.0` → `^6.0.0`)
 
-[Unreleased]: https://github.com/oorabona/node-liblzma/compare/v7.0.0...HEAD
-[7.0.0]: https://github.com/oorabona/node-liblzma/compare/v6.1.0...v7.0.0
+[Unreleased]: https://github.com/oorabona/node-liblzma/compare/v6.1.0...HEAD
 [v6.1.0]: https://github.com/oorabona/node-liblzma/releases/tag/v6.1.0
 [6.1.0]: https://github.com/oorabona/node-liblzma/releases/tag/v6.1.0

--- a/packages/nxz/README.md
+++ b/packages/nxz/README.md
@@ -1,4 +1,4 @@
-# nxz-cli
+# nxz
 
 Portable `xz`-like CLI tool for Node.js — compress, decompress, and handle `.tar.xz` archives.
 
@@ -8,10 +8,10 @@ Powered by [node-liblzma](https://github.com/oorabona/node-liblzma).
 
 ```bash
 # Run without installing
-npx nxz-cli file.txt              # → file.txt.xz
+npx nxz file.txt              # → file.txt.xz
 
 # Or install globally
-npm install -g nxz-cli
+npm install -g nxz
 nxz file.txt
 ```
 

--- a/packages/nxz/package.json
+++ b/packages/nxz/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nxz-cli",
-  "version": "6.1.0",
+  "name": "nxz",
+  "version": "7.0.0",
   "description": "Portable xz-like CLI tool for Node.js — compress, decompress, and handle tar.xz archives",
   "type": "module",
   "main": "./lib/nxz.js",

--- a/packages/nxz/src/nxz.ts
+++ b/packages/nxz/src/nxz.ts
@@ -228,7 +228,7 @@ With no FILE, or when FILE is -, read standard input.
 Examples:
   nxz file.txt              compress file.txt to file.txt.xz
   nxz -d file.xz            decompress file.xz
-  nxz -T -z dir/            create archive.tar.xz from dir/
+  nxz -T -z dir/            create dir.tar.xz from dir/
   nxz -l archive.tar.xz     list contents of archive
   nxz -d archive.tar.xz     extract archive to current directory
   nxz -d -o dest/ arch.txz  extract archive to dest/

--- a/packages/nxz/test/cli.test.ts
+++ b/packages/nxz/test/cli.test.ts
@@ -110,6 +110,16 @@ describe('nxz CLI', () => {
       expect(result.stdout).toContain('nxz - Node.js XZ compression CLI');
     });
 
+    it('lists tar example with derived output name (regression: PR #134)', () => {
+      // Regression guard: PR #134 fixed the --help example so that
+      // `nxz -T -z dir/` shows `dir.tar.xz` (derived from input) instead
+      // of the stale `archive.tar.xz` hardcoded placeholder.
+      const result = runNxz(['--help']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('nxz -T -z dir/            create dir.tar.xz from dir/');
+    });
+
     it('should display version with --version', () => {
       // Arrange & Act
       const result = runNxz(['--version']);


### PR DESCRIPTION
## Summary

Rename the npm package `nxz-cli` (at `packages/nxz/`) to `nxz`, bump to **7.0.0** (major). Includes a co-located CLI help-text inaccuracy fix.

### Why rename

- The package shipped a binary named `nxz` but was published as `nxz-cli`. This forced users to type `npx --package nxz-cli nxz --help` to run it via npx — an awkward, non-discoverable command surfaced by Copilot review on PR #133.
- Verified the npm name `nxz` is **available** on the registry (HTTP 404 on `https://registry.npmjs.org/nxz`).
- The MEMORY note explaining the original choice ("conflicts with `nx`") was a typing-collision concern (Nrwl's `nx` CLI), not a name-availability issue. With `nxz` actually available, aligning the package name with the binary is the right call.

### Why major bump

`npm i -g nxz-cli` no longer the install path. Consumers MUST update their install commands. Per SemVer convention, this is a breaking change → 7.0.0.

### Diff scope (12 files, +47 -38)

| Area | Files |
|------|-------|
| Package metadata | `packages/nxz/package.json` (name + version), `packages/nxz/.release-it.json` (commit-msg scope), `packages/nxz/CHANGELOG.md` (new v7.0.0 entry at top) |
| CLI source fix | `packages/nxz/src/nxz.ts` line 231: `archive.tar.xz` → `dir.tar.xz` (matches actual default-output derivation in `resolveTarOutput()`) |
| Workflows | `.github/workflows/publish.yml`, `release.yml`, `ci.yml` — every conditional, matrix entry, log line, filter expression updated |
| Docs | root `README.md`, `docs/nxz-usage.md`, `docs/RELEASING.md`, `packages/nxz/README.md`, `TODO.md` |

`pnpm-lock.yaml` does NOT change — pnpm workspace packages are keyed by directory path (`packages/nxz`), not by npm `name` field. Verified clean.

### Senior pre-push review (Opus)

Verified 7/7 priorities:
- ✅ Workflow conditionals: zero missed `'nxz-cli'` literals in `.github/workflows/`
- ✅ CHANGELOG framing: BREAKING CHANGES section + Fix bullet correct, historical entries preserved
- ✅ Help text fix correctness: traced derivation in `resolveTarOutput()` — for `dir/` produces `dir.tar.xz`. Lines 232-233 (`archive.tar.xz` for `-l`/`-d` examples) correctly preserved as generic input names.
- ✅ pnpm-lock claim: confirmed via direct lockfile inspection (importer keyed by `packages/nxz`, no `nxz-cli` reference anywhere)
- ✅ Reference completeness: 0 active refs to `nxz-cli`; only historical CHANGELOG/TODO entries describing past releases (correctly preserved)
- ✅ Test/build sanity: `pnpm install` clean, `pnpm build` PASS, `pnpm --filter nxz test` PASS (63 tests), `pnpm typedoc` PASS, `biome` PASS
- ✅ User-facing docs: install commands, npm links, examples all use `nxz`

One non-blocking observation (L-001): `release-it-preset`'s `resolveSinceBaseline()` will not find a prior `chore(nxz):` commit on master for the v7.0.0 release, so the auto-CHANGELOG flow will fall back to root-tag baseline. **Already mitigated** by the manually-curated v7.0.0 entry in this PR. Subsequent releases (v7.0.1+) will self-anchor correctly.

## Phase B — manual post-merge steps (cannot be automated)

After this PR merges to master:

1. **Placeholder publish** (claims the `nxz` npm name; OIDC requires the package to exist first):
   ```bash
   git checkout master && git pull
   pnpm install --frozen-lockfile
   pnpm build
   cd packages/nxz
   npm publish --access public --provenance
   ```
2. **Configure OIDC trusted publisher** on npmjs.com:
   - URL: https://www.npmjs.com/package/nxz/access
   - Repository: `oorabona/node-liblzma`
   - Workflow: `.github/workflows/publish.yml`
   - Environment: blank
3. **Deprecate `nxz-cli@*`** with redirect message:
   ```bash
   npm deprecate nxz-cli@'>=0.0.0' "Renamed to 'nxz'. Install: npm i -g nxz"
   ```
4. **Verify**: `npx nxz --help` resolves cleanly without `--package` flag; `npm view nxz-cli` shows the deprecation message.

After step 4, future workspace releases flow through `release.yml` → `target_package=nxz` → OIDC-published.

## Test plan

- [ ] CI passes on this PR (lint, typecheck, build, smoke matrix)
- [ ] Codecov stays at 100% (no source-test changes affect coverage)
- [ ] Phase B steps 1-4 completed by maintainer post-merge
- [ ] First post-Phase-B release of `nxz@7.0.x` flows through OIDC without manual intervention
