### PR TITLE
fix(docs): use absolute URLs in typedoc navigationLinks

### DIFF
--- a/packages/tar-xz/typedoc.json
+++ b/packages/tar-xz/typedoc.json
@@ -13,8 +13,8 @@
   "navigationLinks": {
     "GitHub": "https://github.com/oorabona/node-liblzma/tree/master/packages/tar-xz",
     "npm": "https://www.npmjs.com/package/tar-xz",
-    "Demo": "../tar-xz/",
-    "node-liblzma API": "../"
+    "Demo": "https://oorabona.github.io/node-liblzma/tar-xz/",
+    "node-liblzma API": "https://oorabona.github.io/node-liblzma/"
   },
   "plugin": ["typedoc-material-theme"],
   "hideGenerator": true,

--- a/typedoc.json
+++ b/typedoc.json
@@ -13,7 +13,7 @@
   "navigationLinks": {
     "GitHub": "https://github.com/oorabona/node-liblzma",
     "npm": "https://www.npmjs.com/package/node-liblzma",
-    "tar-xz API": "tar-xz-api/"
+    "tar-xz API": "https://oorabona.github.io/node-liblzma/tar-xz-api/"
   },
   "plugin": ["typedoc-material-theme"],
   "hideGenerator": true,


### PR DESCRIPTION
## Summary

Fix 404 on `https://oorabona.github.io/node-liblzma/documents/tar-xz-api/` by replacing relative `navigationLinks` paths with absolute GitHub Pages URLs in both typedoc configs.

### Root cause

PR #133 introduced `navigationLinks` with relative paths:
- Root `typedoc.json`: `"tar-xz API": "tar-xz-api/"`
- `packages/tar-xz/typedoc.json`: `"Demo": "../tar-xz/"`, `"node-liblzma API": "../"`

Typedoc emits these verbatim as `href` values. Relative URLs resolve against the **clicking page's** location, so:
- From root `index.html` → `tar-xz-api/` lands on `/tar-xz-api/` ✅
- From `documents/nxz-usage.html` → `tar-xz-api/` lands on `/documents/tar-xz-api/` ❌ 404

Same depth-fragility hits the tar-xz API navigation when clicking "Demo" or "node-liblzma API" from any subpage of `tar-xz-api/` (e.g. `tar-xz-api/classes/Foo.html`).

### Fix

Use full URLs (`https://oorabona.github.io/node-liblzma/...`). Consistent with the GitHub and npm nav links that were already absolute. Stable against typedoc page-depth.

### Verification

Local rebuild post-fix:

```
docs-site/documents/nxz-usage.html:
  href="https://oorabona.github.io/node-liblzma/tar-xz-api/"

docs-site/tar-xz-api/index.html:
  href="https://oorabona.github.io/node-liblzma/tar-xz/"     (Demo)
  href="https://oorabona.github.io/node-liblzma/"            (node-liblzma API)
  href="https://github.com/oorabona/node-liblzma/tree/master/packages/tar-xz"  (GitHub)
```

### Tradeoff

- Absolute URLs assume the GitHub Pages base URL is stable (`oorabona.github.io/node-liblzma`). If the project ever migrates to a custom domain, these links would need updating. That cost is one-line-per-link and clearly preferable to depth-fragile relative paths that silently 404 on subpages.
- Alternative considered: root-relative paths (`/node-liblzma/tar-xz-api/`) — also depth-stable, but breaks if the repo is ever served from a different basePath. Full URLs are the most explicit choice.

## Test plan

- [ ] CI passes (lint, typecheck, build)
- [ ] Post-merge Pages deploy: `https://oorabona.github.io/node-liblzma/documents/nxz-usage.html` → "tar-xz API" link in nav resolves to `tar-xz-api/index.html` (no 404)
- [ ] Same for `tar-xz-api/` subpages: "Demo" and "node-liblzma API" links resolve correctly
