### PR TITLE
docs(tar-xz): document TarEntryTypeValue with JSDoc + expose in index

### DIFF
--- a/packages/tar-xz/src/index.ts
+++ b/packages/tar-xz/src/index.ts
@@ -32,6 +32,7 @@ export {
   type ExtractOptions,
   type TarEntry,
   TarEntryType,
+  type TarEntryTypeValue,
   type TarEntryWithData,
   type TarInput,
   type TarSourceFile,

--- a/packages/tar-xz/src/types.ts
+++ b/packages/tar-xz/src/types.ts
@@ -32,6 +32,28 @@ export const TarEntryType = {
   PAX_GLOBAL: 'g',
 } as const;
 
+/**
+ * Single-character TAR typeflag literal (POSIX 1003.1 ustar §11.2 + PAX extension).
+ *
+ * On the wire this is a single byte at offset 156 of the 512-byte header block,
+ * interpreted as an ASCII character — not as a numeric value. The digit-shaped
+ * flags (`'0'`–`'7'`) are a historical convention, not encoded integers; PAX
+ * later extended the set with non-digit chars (`'x'`, `'g'`).
+ *
+ * Valid values:
+ * - `'0'` — FILE (regular file)
+ * - `'1'` — HARDLINK
+ * - `'2'` — SYMLINK
+ * - `'3'` — CHARDEV (character device)
+ * - `'4'` — BLOCKDEV (block device)
+ * - `'5'` — DIRECTORY
+ * - `'6'` — FIFO (named pipe)
+ * - `'7'` — CONTIGUOUS file
+ * - `'x'` — PAX_HEADER (extended header for next file)
+ * - `'g'` — PAX_GLOBAL (global PAX header)
+ *
+ * @see {@link TarEntryType} for the named-constant equivalents (e.g. `TarEntryType.FILE === '0'`).
+ */
 export type TarEntryTypeValue = (typeof TarEntryType)[keyof typeof TarEntryType];
 
 /**


### PR DESCRIPTION
## Summary

Document `TarEntryTypeValue` with JSDoc and re-export it from `packages/tar-xz/src/index.ts` so typedoc renders a proper page for it.

### Why

The `TarEntryTypeValue` type alias is the type of `TarEntry.type` and `CreateHeaderOptions.type` — a field users see when consuming the public API. Before this PR:

- typedoc emitted a warning: `TarEntryTypeValue, defined in tar-xz/src/types.ts, is referenced by index.CreateHeaderOptions.type but not included in the documentation`
- All references in the rendered API docs widened the literal-union to bare `string`, which (a) hides the 10 valid values and (b) is misleading: the type is **specifically** a single-character literal from POSIX 1003.1 ustar §11.2 + PAX, not arbitrary string.

User feedback: "je vois que le `TarEntryTypeValue` semble être de type 'string', pourquoi?"

### What

1. **JSDoc block** on the type alias (`packages/tar-xz/src/types.ts`) — 22 lines:
   - Explains the on-wire byte semantics (offset 156, ASCII char, NOT integer)
   - Lists all 10 valid values with POSIX names
   - References `TarEntryType` const for named-constant equivalents

2. **Re-export** `type TarEntryTypeValue` from `packages/tar-xz/src/index.ts` (1 line) — makes it part of the public API surface that typedoc renders.

### Verification

- `pnpm --filter tar-xz exec tsc --noEmit` → 0 errors
- `pnpm --filter tar-xz test` → 214 pass / 3 pre-existing skips
- `pnpm exec typedoc --options packages/tar-xz/typedoc.json` → 0 errors, 1 warning (the pre-existing unrelated `@security` JSDoc tag, dropped from 2)
- Generated `docs-site/tar-xz-api/types/index.TarEntryTypeValue.html` (13.6KB) contains the full JSDoc block: "Single-character TAR typeflag literal", HARDLINK, PAX_HEADER, etc.
- Type is now exposed: `import type { TarEntryTypeValue } from 'tar-xz'` works for consumers.

### Tradeoff: extending the public API surface

`TarEntryTypeValue` was already implicitly part of the public surface (it's the type of public fields). Re-exporting it makes that explicit. No risk of breakage:
- Adding a type re-export is type-only, no runtime change
- Consumers who weren't using it are unaffected
- Consumers who were importing it via deep paths (`tar-xz/src/types`) get a cleaner barrel import alternative

## Test plan

- [ ] CI passes (lint, typecheck, build, smoke matrix)
- [ ] Post-merge Pages deploy: `https://oorabona.github.io/node-liblzma/tar-xz-api/types/index.TarEntryTypeValue.html` renders the full JSDoc description (not just "string")
- [ ] References from `TarEntry.type` and `CreateHeaderOptions.type` field doc pages link to the new page
