### PR TITLE
docs: sync llms.txt and CLAUDE.md to current monorepo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 
 ## Stack
 
-- **Language:** TypeScript strict + `noUncheckedIndexedAccess` / C++ (native) / C (WASM via Emscripten)
+- **Language:** TypeScript strict / C++ (native) / C (WASM via Emscripten). Root `tsconfig.json` has `noUncheckedIndexedAccess: false`; workspace packages `tar-xz` and `@oorabona/nxz` enable it.
 - **Package Manager:** pnpm 10+ workspace
 - **Test Framework:** Vitest 4.x
 - **Linter:** Biome 2.x
@@ -52,7 +52,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 ### Code Style
 - ESM modules (`"type": "module"`)
 - Biome for linting and formatting
-- TypeScript strict mode + `noUncheckedIndexedAccess`
+- TypeScript strict mode (per-package `noUncheckedIndexedAccess`: see Stack section above)
 
 ### Git
 - Branch naming: `<type>/<description>`
@@ -62,7 +62,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 ### Testing
 - Unit tests with Vitest 4.x
 - Coverage: monocart (default) or v8 (`pnpm test:coverage-v8` — lcov output, used by Codecov)
-- 100% lines + branches expected across all packages
+- 100% lines + branches as a project target (currently met; not enforced via vitest threshold — maintained by convention via the `v8 ignore start/stop` discipline for unreachable / negative-ROI branches)
 
 ## Commands Reference
 
@@ -85,7 +85,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 
 ## Important Notes
 
-- Native addon requires liblzma system library or builds from source (XZ tarball downloaded into `deps/` at build time by `binding.gyp`; `deps/` is gitignored, NOT a git submodule)
+- Native addon requires liblzma system library or builds from source (XZ tarball downloaded into `deps/` at build time by `binding.gyp` → `scripts/download_xz_from_github.py`; `deps/` is gitignored, NOT a git submodule)
 - Uses prebuildify for prebuilt binaries; `prebuilds/` must be in `files` array
 - Dual implementation: native N-API + Emscripten WASM (browser condition in package.json exports)
 - License: LGPL-3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,10 @@ node-liblzma/
 │   ├── bindings/            # Native C++ addon source (node-liblzma.cpp / .hpp)
 │   ├── wasm/                # Emscripten WASM bindings (8 files)
 │   └── *.ts                 # TypeScript source files
-├── scripts/                 # Build scripts (Python + JS)
-└── TODO.md                  # Main backlog
+└── scripts/                 # Build scripts (Python + JS)
 ```
+
+Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/issues).
 
 ## Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ node-liblzma/
 │   └── nxz/                 # CLI wrapper (npm: @oorabona/nxz, v7.0.0, binary: nxz)
 ├── src/
 │   ├── bindings/            # Native C++ addon source (node-liblzma.cpp / .hpp)
-│   ├── wasm/                # Emscripten WASM bindings (8 files)
+│   ├── wasm/                # Emscripten WASM bindings + build helpers
 │   └── *.ts                 # TypeScript source files
 └── scripts/                 # Build scripts (Python + JS)
 ```
@@ -45,7 +45,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 - **Linter:** Biome 2.x
 - **Build:** node-gyp + tsc + prebuildify (native); emcc (WASM)
 - **Native binding:** node-addon-api (N-API)
-- **Node.js:** >= 22.0.0
+- **Node.js:** root `node-liblzma` >= 22.0.0; workspace packages `tar-xz` and `@oorabona/nxz` >= 20.0.0
 
 ## Conventions
 
@@ -85,10 +85,9 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 
 ## Important Notes
 
-- Native addon requires liblzma system library or builds from source (deps/xz submodule)
+- Native addon requires liblzma system library or builds from source (XZ tarball downloaded into `deps/` at build time by `binding.gyp`; `deps/` is gitignored, NOT a git submodule)
 - Uses prebuildify for prebuilt binaries; `prebuilds/` must be in `files` array
 - Dual implementation: native N-API + Emscripten WASM (browser condition in package.json exports)
-- `biome` must be invoked via `rtk proxy biome ...` (not `pnpm exec biome`) due to RTK proxy rewrite
 - License: LGPL-3.0
 
 ## Workflow Integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # Project: node-liblzma
 
-NodeJS wrapper for liblzma (XZ/LZMA2 compression library).
+pnpm monorepo — Node.js bindings for liblzma (XZ/LZMA2), with companion tar.xz library and CLI.
+Three packages: `node-liblzma` (root), `tar-xz`, `@oorabona/nxz`.
 
 ## Quick Start
 
@@ -22,35 +23,35 @@ pnpm test:coverage
 
 ```
 node-liblzma/
-├── docs/                    # Documentation (see DOCUMENTATION_INDEX.md)
+├── docs/                    # Documentation (RELEASING.md, BROWSER.md, nxz-usage.md, ...)
 ├── lib/                     # Compiled JavaScript output
+├── packages/
+│   ├── tar-xz/              # tar.xz library (npm: tar-xz, v6.1.0)
+│   └── nxz/                 # CLI wrapper (npm: @oorabona/nxz, v7.0.0, binary: nxz)
 ├── src/
-│   ├── bindings/            # Native C++ addon source
+│   ├── bindings/            # Native C++ addon source (node-liblzma.cpp / .hpp)
+│   ├── wasm/                # Emscripten WASM bindings (8 files)
 │   └── *.ts                 # TypeScript source files
-├── scripts/                 # Build scripts (Python)
-├── TODO.md                  # Main backlog
-└── .claude/
-    └── skills/
-        └── project-experience/     # Project-specific skill
-            ├── SKILL.md             # Patterns, conventions, setup
-            └── GOTCHAS.md           # Project-specific gotchas
+├── scripts/                 # Build scripts (Python + JS)
+└── TODO.md                  # Main backlog
 ```
 
 ## Stack
 
-- **Language:** TypeScript + C++ (native addon)
-- **Package Manager:** pnpm
-- **Test Framework:** Vitest 3.x
+- **Language:** TypeScript strict + `noUncheckedIndexedAccess` / C++ (native) / C (WASM via Emscripten)
+- **Package Manager:** pnpm 10+ workspace
+- **Test Framework:** Vitest 4.x
 - **Linter:** Biome 2.x
-- **Build:** node-gyp + tsc
-- **Native:** node-addon-api (N-API)
+- **Build:** node-gyp + tsc + prebuildify (native); emcc (WASM)
+- **Native binding:** node-addon-api (N-API)
+- **Node.js:** >= 22.0.0
 
 ## Conventions
 
 ### Code Style
 - ESM modules (`"type": "module"`)
 - Biome for linting and formatting
-- TypeScript strict mode
+- TypeScript strict mode + `noUncheckedIndexedAccess`
 
 ### Git
 - Branch naming: `<type>/<description>`
@@ -58,8 +59,9 @@ node-liblzma/
 - Pre-commit hook: nano-staged with Biome
 
 ### Testing
-- Unit tests with Vitest
-- Coverage with monocart or v8
+- Unit tests with Vitest 4.x
+- Coverage: monocart (default) or v8 (`pnpm test:coverage-v8` — lcov output, used by Codecov)
+- 100% lines + branches expected across all packages
 
 ## Commands Reference
 
@@ -68,20 +70,24 @@ node-liblzma/
 | Install | `pnpm install` |
 | Build TS | `pnpm build` |
 | Build Native | `pnpm prebuildify` |
+| Build WASM | `pnpm build:wasm` (requires `emcc` in PATH) |
 | Test | `pnpm test` |
 | Test (watch) | `pnpm test:watch` |
-| Test (coverage) | `pnpm test:coverage` |
+| Test (coverage, monocart) | `pnpm test:coverage` |
+| Test (coverage, v8/lcov) | `pnpm test:coverage-v8` |
 | Lint | `pnpm lint` |
 | Format | `pnpm format:write` |
 | Check all | `pnpm check` |
 | Typecheck | `pnpm type-check` |
+| Generate docs | `pnpm typedoc` |
 | Release | `pnpm release` |
 
 ## Important Notes
 
-- Native addon requires liblzma system library or will build from source
-- Uses prebuildify for prebuilt binaries
-- Supports Node.js >= 16.0.0
+- Native addon requires liblzma system library or builds from source (deps/xz submodule)
+- Uses prebuildify for prebuilt binaries; `prebuilds/` must be in `files` array
+- Dual implementation: native N-API + Emscripten WASM (browser condition in package.json exports)
+- `biome` must be invoked via `rtk proxy biome ...` (not `pnpm exec biome`) due to RTK proxy rewrite
 - License: LGPL-3.0
 
 ## Workflow Integration

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,9 @@
 # node-liblzma
 
 > Node.js bindings for liblzma (XZ/LZMA2 compression). Provides streaming
-> and buffer APIs compatible with zlib, plus a portable CLI tool (nxz).
-> Supports prebuilt binaries for Linux, macOS, and Windows.
+> and buffer APIs compatible with zlib. Dual implementation: native N-API
+> addon (Linux/macOS/Windows) + Emscripten WASM (browser/worker).
+> Requires Node.js >= 22.0.0. License: LGPL-3.0.
 
 ## Installation
 
@@ -12,37 +13,53 @@ npm install node-liblzma
 
 ## Key APIs
 
-- [Streaming API](https://github.com/oorabona/node-liblzma#streaming-api): `createXz()`, `createUnxz()` - zlib-compatible transform streams
-- [Buffer API](https://github.com/oorabona/node-liblzma#buffer-api): `xz()`, `unxz()`, `xzSync()`, `unxzSync()` - callback and sync variants
-- [Promise API](https://github.com/oorabona/node-liblzma#promise-api): `xzAsync()`, `unxzAsync()` - modern async/await support
-- [File API](https://github.com/oorabona/node-liblzma#file-api): `xzFile()`, `unxzFile()` - compress/decompress files directly
-- [Utility API](https://github.com/oorabona/node-liblzma#utility-functions): `isXZ()`, `parseFileIndex()`, `versionString()` - format detection and metadata
+- [Quick Start](https://github.com/oorabona/node-liblzma#quick-start): Installation and first examples
+- [API Reference](https://github.com/oorabona/node-liblzma#api-reference): `createXz()`, `createUnxz()`, `xzAsync()`, `unxzAsync()`, `xzSync()`, `unxzSync()`, `xzFile()`, `unxzFile()`, `isXZ()`, `parseFileIndex()`, `versionString()`
+- [API Comparison with Zlib](https://github.com/oorabona/node-liblzma#api-comparison-with-zlib): Drop-in replacement guide
+- [Browser Usage](https://github.com/oorabona/node-liblzma#browser-usage): WASM/Emscripten mode for bundlers and workers
+- [Benchmark](https://github.com/oorabona/node-liblzma#benchmark): Performance comparison with native xz
 
 ## CLI Tool (nxz)
 
-Portable xz-like command line tool included in the package:
+The CLI is published as a **separate package** (`@oorabona/nxz`, v7.0.0) — not bundled with `node-liblzma`.
+The binary name is `nxz`.
 
 ```bash
-npx node-liblzma file.txt        # compress
-npx node-liblzma -d file.xz      # decompress
-npx node-liblzma -l file.xz      # list info
-npx node-liblzma -9e large.bin   # max compression
+# One-shot (no install required)
+npx @oorabona/nxz file.txt        # compress
+npx @oorabona/nxz -d file.xz      # decompress
+npx @oorabona/nxz -l file.xz      # list info
+npx @oorabona/nxz -9e large.bin   # max compression
+
+# After global install
+npm i -g @oorabona/nxz
+nxz file.txt
+nxz -d file.xz
 ```
 
-Options: `-z` compress, `-d` decompress, `-l` list, `-k` keep, `-f` force, `-c` stdout, `-o FILE` output, `-0`.`-9` preset, `-e` extreme, `-v` verbose, `-q` quiet
+Options: `-z` compress, `-d` decompress, `-l` list, `-k` keep, `-f` force, `-c` stdout, `-o FILE` output, `-0`..`-9` preset, `-e` extreme, `-v` verbose, `-q` quiet
+
+More: [CLI Tool (nxz)](https://github.com/oorabona/node-liblzma#cli-tool-nxz)
+
+## Ecosystem Packages
+
+- [`tar-xz`](https://github.com/oorabona/node-liblzma#ecosystem-packages) (v6.1.0) — tar.xz archive creation and extraction for Node and browser
+- [`@oorabona/nxz`](https://github.com/oorabona/node-liblzma#nxz--standalone-cli) (v7.0.0) — standalone CLI (was `nxz-cli`, deprecated)
 
 ## Documentation
 
 - [README](https://github.com/oorabona/node-liblzma#readme): Quick start and examples
-- [TypeDoc API Reference](https://oorabona.github.io/node-liblzma/): Full API documentation
-- [Migration from zlib](https://github.com/oorabona/node-liblzma#compatibility-with-zlib): Drop-in replacement guide
+- [TypeDoc API — node-liblzma](https://oorabona.github.io/node-liblzma/): Full root package API
+- [TypeDoc API — tar-xz](https://oorabona.github.io/node-liblzma/tar-xz-api/): tar-xz package API
+- [nxz usage page](https://oorabona.github.io/node-liblzma/documents/nxz-usage.html): CLI reference
+- [Benchmark](https://github.com/oorabona/node-liblzma#benchmark): Performance numbers
 
 ## Quick Examples
 
 ```typescript
 import { xzAsync, unxzAsync, createXz } from 'node-liblzma';
 
-// Buffer API
+// Promise API
 const compressed = await xzAsync(Buffer.from('Hello World'));
 const original = await unxzAsync(compressed);
 
@@ -57,5 +74,4 @@ createReadStream('input.txt')
 
 - [Contributing Guide](https://github.com/oorabona/node-liblzma/blob/master/CONTRIBUTING.md): How to contribute
 - [Changelog](https://github.com/oorabona/node-liblzma/blob/master/CHANGELOG.md): Version history
-- [Benchmark](https://github.com/oorabona/node-liblzma#benchmark): Performance comparison with native xz
 - [License](https://github.com/oorabona/node-liblzma/blob/master/LICENSE): LGPL-3.0


### PR DESCRIPTION
Sync both files against current source-of-truth: monorepo with 3 packages (`node-liblzma`, `tar-xz`, `@oorabona/nxz`), Node >=22, Vitest 4.x, no broken anchors, no broken `npx` examples, no references to non-existent paths. Pure docs accuracy fix, no code/runtime change.