### PR TITLE
chore: enrich package metadata (description + keywords) for 3 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-liblzma",
   "version": "5.0.0",
-  "description": "Native Node.js bindings for liblzma (XZ/LZMA2). Streaming, buffer and async APIs with browser support via WebAssembly. Drop-in zlib-compatible, TypeScript-first, prebuilt binaries for Linux/macOS/Windows.",
+  "description": "Native Node.js bindings for liblzma (XZ/LZMA2). Streaming, buffer and async APIs with browser support via WebAssembly. zlib-like API, TypeScript-first, prebuilt binaries for Linux/macOS/Windows.",
   "type": "module",
   "main": "./lib/lzma.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-liblzma",
   "version": "5.0.0",
-  "description": "NodeJS wrapper for liblzma",
+  "description": "Native Node.js bindings for liblzma (XZ/LZMA2). Streaming, buffer and async APIs with browser support via WebAssembly. Drop-in zlib-compatible, TypeScript-first, prebuilt binaries for Linux/macOS/Windows.",
   "type": "module",
   "main": "./lib/lzma.js",
   "exports": {
@@ -107,6 +107,9 @@
   },
   "keywords": [
     "module",
+    "node",
+    "nodejs",
+    "typescript",
     "lzma",
     "lzma2",
     "xz",
@@ -114,6 +117,11 @@
     "compress",
     "uncompress",
     "decompress",
+    "streaming",
+    "wasm",
+    "webassembly",
+    "browser",
+    "zlib",
     "filters",
     "binding",
     "native"

--- a/packages/nxz/package.json
+++ b/packages/nxz/package.json
@@ -46,12 +46,18 @@
   "keywords": [
     "xz",
     "lzma",
+    "lzma2",
     "compress",
     "decompress",
     "tar",
     "tar.xz",
+    "archive",
+    "extract",
     "cli",
-    "nxz"
+    "command-line",
+    "nxz",
+    "node",
+    "nodejs"
   ],
   "author": "Olivier ORABONA",
   "license": "LGPL-3.0",

--- a/packages/tar-xz/package.json
+++ b/packages/tar-xz/package.json
@@ -67,6 +67,8 @@
   },
   "keywords": [
     "tar",
+    "tar.xz",
+    "tar-xz",
     "xz",
     "lzma",
     "lzma2",

--- a/packages/tar-xz/package.json
+++ b/packages/tar-xz/package.json
@@ -74,8 +74,14 @@
     "decompress",
     "archive",
     "extract",
+    "streaming",
+    "async-iterable",
+    "node",
+    "nodejs",
+    "typescript",
     "browser",
-    "wasm"
+    "wasm",
+    "webassembly"
   ],
   "author": "Olivier ORABONA",
   "license": "LGPL-3.0",


### PR DESCRIPTION
## Summary

Polish the npm metadata of the 3 published packages so the npm.org pages and search results match the README pitch.

### Why

Direct audit found that the **root `node-liblzma`** package — the most visible one — had a 4-word description ("NodeJS wrapper for liblzma") that doesn't reflect anything the README leads with: WASM/browser support, streaming/buffer/async APIs, TypeScript-first, prebuilt binaries. Keywords were also missing the search terms developers actually use (`node`, `nodejs`, `typescript`, `streaming`, `wasm`, `webassembly`, `browser`).

The workspace packages were closer to correct but still missing some axes (`tar-xz` had `wasm` but not `webassembly`, missed `streaming`/`async-iterable`; `nxz` missed `lzma2`/`archive`/`extract`/`command-line`).

### Changes (3 files, +23 −3)

| File | Change |
|------|------|
| `package.json` | description rewritten to match README pitch; keywords +8 (`node`, `nodejs`, `typescript`, `streaming`, `wasm`, `webassembly`, `browser`, `zlib`) |
| `packages/tar-xz/package.json` | keywords +8 (`tar.xz`, `tar-xz`, `streaming`, `async-iterable`, `node`, `nodejs`, `typescript`, `webassembly`) |
| `packages/nxz/package.json` | keywords +6 (`lzma2`, `archive`, `extract`, `command-line`, `node`, `nodejs`) |

No version bumps — these are SEO/discoverability metadata, not user-visible behavior or runtime contract. The root `description` change WILL be visible on the next npm publish (next release of `node-liblzma`), but until then the npm page keeps the old description.

### Verification

- `pnpm install --frozen-lockfile` runs clean (no peer-dep warnings, no cascade)
- npm-spec validity: descriptions are <300 chars; keyword arrays are 14-18 entries each (well within npm's display limit)
- Each kept keyword aligns with the package's actual capability surface

## Test plan

- [ ] CI passes (lint, typecheck, build, smoke matrix) — pure JSON metadata change, should be a no-op
- [ ] Next release of `node-liblzma` republishes with the new description / keywords (the published metadata only refreshes on publish, not on merge)
