### PR TITLE
fix(ci): install node-gyp globally alongside prebuildify

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -131,8 +131,10 @@ jobs:
       - name: Run prepare (git hooks + TypeScript build)
         run: pnpm run prepare
 
-      - name: Install prebuildify globally
-        run: npm install -g prebuildify
+      - name: Install prebuildify and node-gyp globally
+        # node-gyp is no longer bundled with npm@11+ (default with Node 24);
+        # prebuildify spawns `node-gyp` by name and needs it in PATH.
+        run: npm install -g prebuildify node-gyp
 
       - name: Prebuild native modules
         run: |


### PR DESCRIPTION
Fix `Build Prebuilds` failure (`spawn node-gyp ENOENT`) caused by npm@11 (Node 24 default) no longer bundling node-gyp. Install `node-gyp` globally alongside `prebuildify` so prebuildify's spawned `node-gyp` resolves. Inline comment added to prevent regression. Unblocks the v5.0.1 metadata-refresh release that failed at run 25437605125.