### PR TITLE
fix(stream): drop @ts-expect-error via intersection-cast (forward-compat with @types/node 25.7.0)

### DIFF
--- a/src/wasm/stream.ts
+++ b/src/wasm/stream.ts
@@ -65,7 +65,10 @@ export function createXz(opts?: LZMAOptions): TransformStream<Uint8Array, Uint8A
       }
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
-       Part of the Streams spec but not yet in TypeScript's DOM lib. */
+       Part of the Streams spec; @types/node 25.7.0 added it to the
+       Transformer interface, earlier versions did not. We use @ts-expect-error
+       (not @ts-expect-error) so the directive is harmless on the newer
+       typings where the property already exists. */
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
   });
@@ -125,7 +128,7 @@ export function createUnxz(): TransformStream<Uint8Array, Uint8Array> {
       }
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
-       Part of the Streams spec but not yet in TypeScript's DOM lib. */
+       See createXz() for the rationale on @ts-expect-error vs @ts-expect-error. */
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
   });

--- a/src/wasm/stream.ts
+++ b/src/wasm/stream.ts
@@ -5,6 +5,7 @@
  * Use `.pipeThrough()` instead of `.pipe()`.
  */
 
+import type { Transformer } from 'node:stream/web';
 import { createLZMAError } from '../errors.js';
 import type { LZMAOptions } from '../types.js';
 import { code, decoderInit, encoderInit, end, getModule } from './bindings.js';
@@ -65,13 +66,13 @@ export function createXz(opts?: LZMAOptions): TransformStream<Uint8Array, Uint8A
       }
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
-       Part of the Streams spec; @types/node 25.7.0 added it to the
-       Transformer interface, earlier versions did not. We use `@ts-expect-error`
-       (not `@ts-expect-error`) so the directive is harmless on the newer
-       typings where the property already exists. */
-    // biome-ignore lint/suspicious/noTsIgnore: @ts-expect-error is intentional — forward-compat with @types/node 25.7.0 (Transformer.cancel typing drift)
-    // @ts-expect-error cancel is a valid Transformer method per Streams spec
+       Part of the Streams spec; @types/node added `cancel?:` to the Transformer
+       interface in 25.7.0. The intersection cast accepts the property on both
+       older typings (where it's absent) and newer typings (where it's present),
+       keeping the typecheck stable across `@types/node` minor bumps. */
     cancel: doCleanup,
+  } as Transformer<Uint8Array, Uint8Array> & {
+    cancel?: (reason: unknown) => void | PromiseLike<void>;
   });
 }
 
@@ -129,10 +130,10 @@ export function createUnxz(): TransformStream<Uint8Array, Uint8Array> {
       }
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
-       See createXz() for the rationale on `@ts-expect-error` vs `@ts-expect-error`. */
-    // biome-ignore lint/suspicious/noTsIgnore: see createXz()
-    // @ts-expect-error cancel is a valid Transformer method per Streams spec
+       See createXz() for the rationale on the intersection cast. */
     cancel: doCleanup,
+  } as Transformer<Uint8Array, Uint8Array> & {
+    cancel?: (reason: unknown) => void | PromiseLike<void>;
   });
 }
 

--- a/src/wasm/stream.ts
+++ b/src/wasm/stream.ts
@@ -66,8 +66,8 @@ export function createXz(opts?: LZMAOptions): TransformStream<Uint8Array, Uint8A
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
        Part of the Streams spec; @types/node 25.7.0 added it to the
-       Transformer interface, earlier versions did not. We use @ts-expect-error
-       (not @ts-expect-error) so the directive is harmless on the newer
+       Transformer interface, earlier versions did not. We use `@ts-expect-error`
+       (not `@ts-expect-error`) so the directive is harmless on the newer
        typings where the property already exists. */
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
@@ -128,7 +128,7 @@ export function createUnxz(): TransformStream<Uint8Array, Uint8Array> {
       }
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
-       See createXz() for the rationale on @ts-expect-error vs @ts-expect-error. */
+       See createXz() for the rationale on `@ts-expect-error` vs `@ts-expect-error`. */
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
   });

--- a/src/wasm/stream.ts
+++ b/src/wasm/stream.ts
@@ -69,6 +69,7 @@ export function createXz(opts?: LZMAOptions): TransformStream<Uint8Array, Uint8A
        Transformer interface, earlier versions did not. We use `@ts-expect-error`
        (not `@ts-expect-error`) so the directive is harmless on the newer
        typings where the property already exists. */
+    // biome-ignore lint/suspicious/noTsIgnore: @ts-expect-error is intentional — forward-compat with @types/node 25.7.0 (Transformer.cancel typing drift)
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
   });
@@ -129,6 +130,7 @@ export function createUnxz(): TransformStream<Uint8Array, Uint8Array> {
     },
     /* cancel() frees WASM resources when the readable side is cancelled.
        See createXz() for the rationale on `@ts-expect-error` vs `@ts-expect-error`. */
+    // biome-ignore lint/suspicious/noTsIgnore: see createXz()
     // @ts-expect-error cancel is a valid Transformer method per Streams spec
     cancel: doCleanup,
   });

--- a/test/wasm/stream-directive-hygiene.test.ts
+++ b/test/wasm/stream-directive-hygiene.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Forward-compat guard for `src/wasm/stream.ts`.
+ *
+ * `@types/node` adds and (more rarely) removes typed members of the Streams
+ * interfaces across minor bumps. The file deliberately uses an intersection
+ * cast on `TransformStream` constructor calls so it needs ZERO TypeScript
+ * suppression directives. Any directive — in either the expect-error or
+ * ignore form — would either mask a real upstream regression, or fire
+ * TS2578 ("unused directive") the moment the typing it suppresses lands
+ * upstream, breaking the daily Refresh Lockfile workflow.
+ *
+ * This test is the deterministic regression detector for that invariant.
+ */
+describe('src/wasm/stream.ts — TS directive hygiene', () => {
+  it('contains no @ts-ignore or @ts-expect-error directive', () => {
+    const path = fileURLToPath(new URL('../../src/wasm/stream.ts', import.meta.url));
+    const source = readFileSync(path, 'utf8');
+
+    // Match the directive form specifically (with leading `//` and a word boundary
+    // after the directive name), so the rule name appearing inside a doc-comment
+    // or string literal does not produce a false positive.
+    const directivePattern = /\/\/\s*@ts-(expect-error|ignore)\b/;
+    expect(source).not.toMatch(directivePattern);
+  });
+});


### PR DESCRIPTION
## Summary

Unblocks the daily `Refresh Lockfile` workflow, which has been producing one "build failed" PR per day since 2026-05-06 (#143-#145, #149-#152 — 7 stale PRs).

## Root cause

`@types/node@25.7.0` added `cancel?: TransformerCancelCallback` to the `Transformer` interface in `stream/web.d.ts`. The catalog spec `^25.5.0` accepts it during unfrozen install, so:

- Committed `pnpm-lock.yaml` pins `@types/node@25.6.0` (no `cancel`) → the `@ts-expect-error` directives in `src/wasm/stream.ts` are necessary and silent.
- Refresh-lockfile workflow runs `pnpm install --no-frozen-lockfile` → resolves to 25.7.0 (has `cancel`) → directives become unused → **TS2578** → build step fails → workflow opens a "build failed" PR every day.

The same regression will hit master CI the next time `@types/node` lands at >= 25.7.0 in the lockfile (Dependabot bump, manual upgrade, etc.).

## Fix

**Drop the directives entirely.** Cast the inline `Transformer` literal as `Transformer<Uint8Array, Uint8Array> & { cancel?: (reason: unknown) => void | PromiseLike<void> }` at both `new TransformStream({...})` construction sites in `src/wasm/stream.ts`. The intersection adds the missing `cancel?:` on `@types/node@25.6.0` (where the base `Transformer` has no `cancel`) and is structurally compatible on 25.7.0+ (where the base has the typed `cancel?:`). The cast signature mirrors the Streams spec / `TransformerCancelCallback` so the call contract stays visible.

Net result: zero `@ts-expect-error` / `@ts-ignore` / `biome-ignore` in the file. Biome's `lint/suspicious/noTsIgnore` rule has nothing to act on. The pre-commit hook is a no-op for this file.

| Typings state | Before this PR (`@ts-expect-error`) | After this PR (intersection cast) |
|---|---|---|
| `cancel` absent (25.6.0) | suppresses error | structurally adds the property |
| `cancel` present (25.7.0+) | **TS2578 fails build** | structurally compatible — no friction |

### Why not switch to `@ts-ignore`?

The intuitive fix — swap `@ts-expect-error` → `@ts-ignore` — fails silently. The project's `pre-commit` hook (`simple-git-hooks` → `pnpm exec nano-staged`) runs `biome check --write` on staged `.ts` files. Biome v2's `lint/suspicious/noTsIgnore` rule has a **safe fix** (auto-applied with `--write`) that rewrites `@ts-ignore` → `@ts-expect-error` as a text replace — even when the directive is suppressed by a `biome-ignore` pragma on the line above. Three earlier rounds of this PR tried the swap and watched the rewrite undo it between `git add` and `git commit`. The intersection-cast sidesteps the rule entirely.

## Regression guard

Adds `test/wasm/stream-directive-hygiene.test.ts`. The test reads `src/wasm/stream.ts` and asserts that no `// @ts-expect-error` or `// @ts-ignore` directive is present. If a future change re-introduces either, the test fails on every PR — not only on the next lockfile refresh.

## Verification

- `pnpm type-check` clean against both `@types/node@25.6.0` (lockfile pin) and `@types/node@25.7.0` (refresh-lockfile resolution).
- `biome check src/wasm/stream.ts` clean (with and without `--write`).
- New hygiene test passes locally.

## Test plan

- [ ] CI passes on this PR with `@types/node@25.6.0`
- [ ] Next `Refresh Lockfile` cron commits the refreshed lockfile directly to master (no more "build failed" PR)
- [ ] The 7 stale PRs (#143-145, #149-152) can be closed without action

## Follow-ups (not blocking)

- Closing #143-145 / #149-152 explicitly once this merges.
- (L) The hygiene test only covers `src/wasm/stream.ts`. If similar drift hits other files, the test can be generalised — currently scoped narrowly because that file is the only known affected surface.
