### PR TITLE
ci(codeql): scan demo and examples directories

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,6 @@ on:
       - 'pnpm-lock.yaml'
       - '**.md'
       - 'docs/**'
-      - 'demo/**'
-      - 'examples/**'
       - '.github/dependabot.yml'
   schedule:
     - cron: '0 0 * * 0'  # Weekly, Sunday 00:00 UTC


### PR DESCRIPTION
Removes `demo/**` and `examples/**` from CodeQL `paths-ignore` so security analysis covers the implementation examples (real TS/JS), not just library source. Remaining ignores (manifests, lockfile, markdown, docs) contain nothing CodeQL analyzes.

Part of unblocking PR merges: the repo ruleset no longer hard-gates merges on `copilot_code_review` (Copilot quota) or `code_scanning` (which conflicted with `paths-ignore` on dependency/doc PRs). CodeQL still runs on all code PRs, push to master, and the weekly schedule.