### PR TITLE
fix(wasm): build with WASM_BIGINT so .xz works on Node 26 and Deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,10 +586,57 @@ jobs:
           retry_on: error
           command: pnpm test
 
+  # WASM runtime compatibility: the .xz i64 boundary (memlimit) must work on
+  # strict-BigInt engines. Node <=24 silently coerced BigInt->Number at the
+  # legalized i64 boundary; Node 26 and Deno throw. Built with WASM_BIGINT, the
+  # decoder accepts BigInt natively. This job locks the regression on both
+  # runtimes (the rest of the matrix only covers Node 22/24). See issue #165.
+  wasm-runtime-compat:
+    name: WASM runtime compat (Node 26 + Deno)
+    needs: [setup, build-wasm]
+    if: >-
+      needs.setup.outputs.run-smoke-only == 'true' ||
+      needs.setup.outputs.run-full-matrix == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-build
+          path: src/wasm
+
+      - name: Setup build environment (Node 26)
+        uses: ./.github/actions/setup-env
+        with:
+          node-version: '26'
+          cache-prefix: 'wasm-compat'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build (tsc + copy WASM artifacts)
+        run: pnpm build
+
+      - name: WASM smoke on Node 26
+        run: node test/wasm/runtime-smoke.mjs
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: WASM smoke on Deno
+        run: deno run -A test/wasm/runtime-smoke.mjs
+
   # Final summary
   summary:
     name: CI Summary
-    needs: [setup, quality, build-wasm, coverage, smoke-test, full-test, threading-test]
+    needs: [setup, quality, build-wasm, coverage, smoke-test, full-test, threading-test, wasm-runtime-compat]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -613,6 +660,7 @@ jobs:
           echo "- **Smoke Tests**: ${{ needs.smoke-test.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Full Tests**: ${{ needs.full-test.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Threading Tests**: ${{ needs.threading-test.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **WASM runtime compat**: ${{ needs.wasm-runtime-compat.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Overall status
@@ -621,6 +669,7 @@ jobs:
           SMOKE_OK="${{ needs.smoke-test.result == 'success' || needs.smoke-test.result == 'skipped' }}"
           FULL_OK="${{ needs.full-test.result == 'success' || needs.full-test.result == 'skipped' }}"
           THREADING_OK="${{ needs.threading-test.result == 'success' || needs.threading-test.result == 'skipped' }}"
+          WASM_COMPAT_OK="${{ needs.wasm-runtime-compat.result == 'success' || needs.wasm-runtime-compat.result == 'skipped' }}"
 
           # Ensure at least one test suite actually ran (not just skipped)
           SMOKE_RAN="${{ needs.smoke-test.result == 'success' }}"
@@ -631,7 +680,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "$QUALITY_OK" == "true" && "$COVERAGE_OK" == "true" && "$SMOKE_OK" == "true" && "$FULL_OK" == "true" && "$THREADING_OK" == "true" ]]; then
+          if [[ "$QUALITY_OK" == "true" && "$COVERAGE_OK" == "true" && "$SMOKE_OK" == "true" && "$FULL_OK" == "true" && "$THREADING_OK" == "true" && "$WASM_COMPAT_OK" == "true" ]]; then
             echo "### ✅ All checks passed!" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ❌ Some checks failed" >> $GITHUB_STEP_SUMMARY

--- a/src/wasm/build.sh
+++ b/src/wasm/build.sh
@@ -118,6 +118,7 @@ EXPORTED_FUNCTIONS=$(echo "$EXPORTED_FUNCTIONS" | tr -d ' \n')
 emcc -Oz -flto \
     -I"$LIBLZMA_SRC/src/liblzma/api" \
     -s WASM=1 \
+    -s WASM_BIGINT=1 \
     -s FILESYSTEM=0 \
     -s MODULARIZE=1 \
     -s EXPORT_ES6=1 \

--- a/test/wasm/runtime-smoke.mjs
+++ b/test/wasm/runtime-smoke.mjs
@@ -1,0 +1,76 @@
+// Cross-runtime WASM smoke for node-liblzma#165.
+// Runs on Node and Deno against the BUILT output (lib/wasm). Exercises both
+// i64 boundaries that broke under strict-BigInt engines (Node 26, Deno):
+//   - createUnxz()  -> decoderInit -> _lzma_stream_decoder(ptr, i64, 0)   (function arg)
+//   - unxzAsync()   -> streamBufferDecode -> setValue(ptr, i64, 'i64')    (heap write)
+// Requires the package to be built first (`pnpm build`). Exits non-zero on failure.
+//
+// The Emscripten glue is compiled with ENVIRONMENT='web,worker', so under Node
+// and Deno we must hand the .wasm bytes to the factory via a custom loader
+// (matching test/wasm/wasm-helpers.utils.ts) instead of the default fetch path.
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createUnxz, createXz, initModule, unxzAsync, xzAsync } from '../../lib/wasm/index.js';
+
+const wasmDir = join(dirname(fileURLToPath(import.meta.url)), '../../lib/wasm');
+
+await initModule(async () => {
+  const wasmBinary = await readFile(join(wasmDir, 'liblzma.wasm'));
+  const { default: createLZMA } = await import(pathToFileURL(join(wasmDir, 'liblzma.js')).href);
+  return createLZMA({ wasmBinary });
+});
+
+const te = new TextEncoder();
+
+function readableOf(bytes) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream) {
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+const equal = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+function exit(code) {
+  if (typeof process !== 'undefined' && process.exit) process.exit(code);
+  else if (typeof Deno !== 'undefined') Deno.exit(code);
+  else if (code !== 0) throw new Error(`smoke failed (code ${code})`);
+}
+
+const data = te.encode('node-liblzma#165 wasm runtime smoke '.repeat(2000));
+
+// Stream path (the reported crash site).
+const streamCompressed = await collect(readableOf(data).pipeThrough(createXz()));
+const streamRestored = await collect(readableOf(streamCompressed).pipeThrough(createUnxz()));
+const streamOk = equal(streamRestored, data);
+
+// Buffer path (setValue i64).
+const bufferCompressed = await xzAsync(data);
+const bufferRestored = await unxzAsync(bufferCompressed);
+const bufferOk = equal(bufferRestored, data);
+
+const runtime =
+  typeof Deno !== 'undefined' ? `Deno ${Deno.version.deno}` : `Node ${process.version}`;
+console.log(`[${runtime}] stream=${streamOk} buffer=${bufferOk}`);
+
+if (!streamOk || !bufferOk) {
+  console.error('WASM runtime smoke FAILED');
+  exit(1);
+}
+console.log('WASM runtime smoke OK');


### PR DESCRIPTION
Closes #165.

## Bug

WASM `.xz` decode throws `TypeError: Cannot convert a BigInt value to a number` at `createUnxz()` → `decoderInit` → `_lzma_stream_decoder` on **Node 26** and **Deno** (reported on 5.0.2). Node ≤ 24 silently coerced the value and worked, so the existing CI matrix (Node 22/24 only) never caught it.

## Cause

The decoder passes a 64-bit `memlimit` across the JS/WASM boundary as a `BigInt`. The module was built **without `-sWASM_BIGINT`**, so Emscripten legalized the `i64` parameter to expect a `Number` — passing a `BigInt` throws on engines that don't coerce. (The buffer path uses `setValue(ptr, …, 'i64')`, which conversely *requires* a `BigInt`, so the two i64 boundaries had opposite expectations.)

## Fix

Build with **`-sWASM_BIGINT=1`**. Both i64 boundaries (function arguments and `setValue('i64')`) then uniformly accept `BigInt` across all engines — no source changes, and it's the precision-correct representation for a `uint64`. WASM_BIGINT is supported on all evergreen browsers and Node 16+.

## Regression lock

New `WASM runtime compat (Node 26 + Deno)` CI job builds the package and runs `test/wasm/runtime-smoke.mjs` on both runtimes, exercising the stream (`createUnxz`) and buffer (`unxzAsync`) decode paths. The rest of the matrix only covers Node 22/24.

## Verification

- Reproduced the failure against published 5.0.2 on Deno; confirmed the smoke detects it (throws on the unfixed build) and passes once loaded correctly.
- `build.sh`, workflow YAML, and Biome all clean. The WASM_BIGINT rebuild + green Node 26 / Deno smoke in this PR's CI is the end-to-end proof (the WASM toolchain isn't available locally).
