### PR TITLE
ci: roll Node matrix to 22/24/26 and align engines to >=22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ['22', '24']
+        node: ['22', '24', '26']
         config:
           - {runtime_link: 'static', use_global_liblzma: false, enable_threads: 'no'}
           - {runtime_link: 'shared', use_global_liblzma: false, enable_threads: 'no'}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Actionable backlog: [GitHub Issues](https://github.com/oorabona/node-liblzma/iss
 - **Linter:** Biome 2.x
 - **Build:** node-gyp + tsc + prebuildify (native); emcc (WASM)
 - **Native binding:** node-addon-api (N-API)
-- **Node.js:** root `node-liblzma` >= 22.0.0; workspace packages `tar-xz` and `@oorabona/nxz` >= 20.0.0
+- **Node.js:** >= 22.0.0 across all packages (root `node-liblzma`, `tar-xz`, `@oorabona/nxz`)
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ xz(Buffer.from('Hello, World!'), (err, compressed) => {
 
 - **Node.js >= 22 required** — Node 20 reached EOL in April 2026
 - **TypeScript 6** — Upgraded from TS 5.x; explicit `types` declarations in workspace tsconfigs
-- **CI matrix updated** — Tests now run on Node 22 + 24 (was 20 + 22)
+- **CI matrix updated** — Tests now run on Node 22, 24, and 26 (was 20 + 22)
 - **XZ Utils 5.8.3** — Updated from 5.8.2
 
 ### v4.0.0 — API Cleanup

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -130,7 +130,7 @@ For publishing alpha, beta, or release candidate versions.
 ### Steps
 
 1. Runs tests and type-check
-2. Builds native modules for Node 20, 22 × Linux, macOS, Windows
+2. Builds N-API prebuilt binaries (Node-version-independent) for linux-x64, macOS-arm64, win32-x64
 3. Publishes to npm with the appropriate dist-tag (`--tag alpha`)
 4. Creates GitHub pre-release
 

--- a/packages/nxz/package.json
+++ b/packages/nxz/package.json
@@ -36,7 +36,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/tar-xz/package.json
+++ b/packages/tar-xz/package.json
@@ -58,7 +58,7 @@
     "SECURITY.md"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Rolls the supported Node versions and aligns the engine declarations + docs.

- **CI full-test matrix `['22','24']` → `['22','24','26']`** — Node 20 is EOL (April 2026) and below the root `engines.node >=22`, so it's already not in the matrix; Node 26 is "Current" and in real-world use (see #165), so it's now covered: **22** (maintenance LTS) + **24** (active LTS) + **26** (current).
- **`tar-xz` and `@oorabona/nxz` engines `>=20` → `>=22`** — both already depend (transitively) on `node-liblzma`, which requires `>=22`, so the `>=20` claim was never actually usable. Now honest.
- **Docs** — `RELEASING.md` described prebuilds as "Node 20, 22"; they're per-platform **N-API** binaries (Node-version-independent), so that's corrected. `CLAUDE.md` Node line and the README CI-matrix note refreshed. The README's historical changelog entries (v2.0.0/v3.2.0) keep their accurate version history.

## Rolling policy

Going forward: test **current + the two newest LTS lines, drop EOL**, re-evaluated at each Node release. When 28 ships and 22 reaches EOL (~2027), shift to `[24, 26, 28]` — three lines, not an ever-growing list.

## Deno

Already covered: the `wasm-runtime-compat` job (added with #165) runs the WASM smoke on Deno. Deno doesn't load the native `.node` addon, so the WASM path (`node-liblzma/wasm`) is the relevant Deno surface — and that's what the job exercises. No native Deno matrix needed.

## Verification

Biome and workflow YAML clean. The new Node 26 matrix leg builds the native addon and runs the suite on Node 26 in this PR's CI.
