### PR TITLE
feat(wasm): zero-config WASM loading on Node and Deno

### DIFF
--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -39,6 +39,8 @@ import { xzAsync, unxzAsync, initModule } from 'node-liblzma/wasm';
 
 Forces WASM usage regardless of environment. Useful for Node.js when you don't want to install native build dependencies.
 
+On **Node and Deno** this works with zero configuration — `initModule()` loads the sibling `liblzma.wasm` from disk automatically. In browsers the binary is resolved by your bundler (or fetched relative to the module URL). Pass a custom loader only to fetch the binary from a non-default location (see [Custom WASM Loading](#custom-wasm-loading)).
+
 ### Inline WASM Import (zero-config)
 
 ```typescript

--- a/src/wasm/bindings.ts
+++ b/src/wasm/bindings.ts
@@ -27,13 +27,67 @@ let moduleInstance: LZMAModule | null = null;
 let modulePromise: Promise<LZMAModule> | null = null;
 
 /**
+ * Dynamically import a Node/Deno built-in without exposing the specifier to
+ * browser bundlers' static analysis. Only ever reached after a Node/Deno
+ * runtime check (see {@link readLocalWasmBinary}), so a browser bundle never
+ * executes it; the variable specifier plus the ignore comments stop
+ * Vite/webpack from trying to resolve `node:*` at build time.
+ */
+function importNodeBuiltin<T>(specifier: string): Promise<T> {
+  return import(/* @vite-ignore */ /* webpackIgnore: true */ specifier) as Promise<T>;
+}
+
+/**
+ * Read the sibling `liblzma.wasm` from disk on Node and Deno.
+ *
+ * The WASM glue is built for `web,worker`, so its default loader resolves the
+ * binary via `import.meta.url` and fetches it — which fails on `file://` URLs
+ * under Node and Deno. On those runtimes we read the file ourselves so it can be
+ * handed to Emscripten as `wasmBinary`. Returns null in browser/worker runtimes,
+ * where Emscripten's built-in fetch loader is used instead.
+ */
+async function readLocalWasmBinary(): Promise<Uint8Array | null> {
+  const g = globalThis as { Deno?: unknown; process?: { versions?: { node?: string } } };
+  const hasDeno = typeof g.Deno !== 'undefined';
+  /* v8 ignore start - under Node vitest only the Node arm runs; the Deno arm is covered by the CI runtime smoke and the browser arm (return null) needs a browser env */
+  const hasNode = !!g.process?.versions?.node;
+  if (!hasNode && !hasDeno) {
+    return null;
+  }
+  /* v8 ignore stop */
+  const { readFile } =
+    await importNodeBuiltin<typeof import('node:fs/promises')>('node:fs/promises');
+  const { fileURLToPath } = await importNodeBuiltin<typeof import('node:url')>('node:url');
+  const wasmPath = fileURLToPath(new URL('./liblzma.wasm', import.meta.url));
+  const buf = await readFile(wasmPath);
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/**
+ * Default module loader: imports the Emscripten glue and, on Node/Deno, supplies
+ * the `.wasm` binary so `node-liblzma/wasm` works with zero configuration.
+ * Browsers fall through to Emscripten's built-in fetch loader.
+ */
+async function loadDefaultModule(): Promise<LZMAModule> {
+  const { default: createLZMA } = await import('./liblzma.js');
+  const wasmBinary = await readLocalWasmBinary();
+  /* v8 ignore start - browser fetch path (wasmBinary === null) only reachable in a browser env */
+  if (!wasmBinary) {
+    return createLZMA();
+  }
+  /* v8 ignore stop */
+  return createLZMA({ wasmBinary });
+}
+
+/**
  * Initialize the WASM module. Must be called before any operation.
  *
- * The module is loaded once and cached. Subsequent calls return
- * the same instance. Can be called with a custom loader for
- * inline/bundled WASM scenarios.
+ * The module is loaded once and cached. Subsequent calls return the same
+ * instance. On Node and Deno the sibling `liblzma.wasm` is loaded automatically
+ * (zero config); pass a custom loader only for inline/bundled scenarios or to
+ * fetch the binary from a custom location.
  *
- * @param loader - Optional custom module loader (for inline WASM)
+ * @param loader - Optional custom module loader (for inline/bundled WASM)
  * @returns The initialized Emscripten module
  */
 export async function initModule(loader?: () => Promise<LZMAModule>): Promise<LZMAModule> {
@@ -45,14 +99,7 @@ export async function initModule(loader?: () => Promise<LZMAModule>): Promise<LZ
   }
 
   modulePromise = (async () => {
-    if (loader) {
-      moduleInstance = await loader();
-      /* v8 ignore start - default import path only used in browser environments */
-    } else {
-      const { default: createLZMA } = await import('./liblzma.js');
-      moduleInstance = (await createLZMA()) as LZMAModule;
-      /* v8 ignore stop */
-    }
+    moduleInstance = loader ? await loader() : await loadDefaultModule();
     return moduleInstance;
   })();
 

--- a/test/wasm/bindings.test.ts
+++ b/test/wasm/bindings.test.ts
@@ -438,6 +438,23 @@ describe('WASM Bindings (Block 2)', () => {
     });
   });
 
+  describe('zero-config default loader', () => {
+    it('should load on Node with no custom loader (initModule() zero-config)', async () => {
+      // The default loader reads the sibling liblzma.wasm itself, so
+      // node-liblzma/wasm works in Node/Deno without a custom wasmBinary loader.
+      resetModule();
+      const mod = await initModule();
+      expect(mod).toBeDefined();
+      expect(mod._lzma_easy_encoder).toBeTypeOf('function');
+      // Sanity: the module is actually functional, not just constructed.
+      expect(versionString()).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    afterAll(async () => {
+      await loadWasmModule();
+    });
+  });
+
   describe('Cross-compatibility with native', () => {
     it('should produce output decompressible by native xz tool', () => {
       // This test validates that WASM output is standard-compliant XZ

--- a/test/wasm/runtime-smoke.mjs
+++ b/test/wasm/runtime-smoke.mjs
@@ -3,23 +3,13 @@
 // i64 boundaries that broke under strict-BigInt engines (Node 26, Deno):
 //   - createUnxz()  -> decoderInit -> _lzma_stream_decoder(ptr, i64, 0)   (function arg)
 //   - unxzAsync()   -> streamBufferDecode -> setValue(ptr, i64, 'i64')    (heap write)
+// Also asserts the zero-config loader: initModule() with no arguments must load
+// the sibling .wasm on both Node and Deno (no custom wasmBinary loader needed).
 // Requires the package to be built first (`pnpm build`). Exits non-zero on failure.
-//
-// The Emscripten glue is compiled with ENVIRONMENT='web,worker', so under Node
-// and Deno we must hand the .wasm bytes to the factory via a custom loader
-// (matching test/wasm/wasm-helpers.utils.ts) instead of the default fetch path.
-import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createUnxz, createXz, initModule, unxzAsync, xzAsync } from '../../lib/wasm/index.js';
 
-const wasmDir = join(dirname(fileURLToPath(import.meta.url)), '../../lib/wasm');
-
-await initModule(async () => {
-  const wasmBinary = await readFile(join(wasmDir, 'liblzma.wasm'));
-  const { default: createLZMA } = await import(pathToFileURL(join(wasmDir, 'liblzma.js')).href);
-  return createLZMA({ wasmBinary });
-});
+// Zero-config: the default loader reads the sibling liblzma.wasm on Node/Deno.
+await initModule();
 
 const te = new TextEncoder();
 

--- a/test/wasm/wasm-helpers.utils.ts
+++ b/test/wasm/wasm-helpers.utils.ts
@@ -1,36 +1,19 @@
 /**
  * Test helpers for loading the WASM module in Node.js.
  *
- * The Emscripten module is compiled with ENVIRONMENT='web,worker',
- * so in Node.js we must supply the WASM binary via moduleArg.wasmBinary.
+ * `initModule()` now reads the sibling `liblzma.wasm` automatically on Node and
+ * Deno (zero config), so tests no longer need to supply `moduleArg.wasmBinary`
+ * by hand — calling it with no arguments exercises the default loader path.
  */
 
-import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { initModule, resetModule } from '../../src/wasm/bindings.js';
 import type { LZMAModule } from '../../src/wasm/types.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const WASM_DIR = join(__dirname, '../../src/wasm');
-const WASM_FILE = join(WASM_DIR, 'liblzma.wasm');
-const GLUE_FILE = join(WASM_DIR, 'liblzma.js');
-
 /**
- * Load the WASM module for Node.js testing.
- * Reads the .wasm binary from disk and passes it to the Emscripten factory.
+ * Load the WASM module for Node.js testing via the zero-config default loader.
  */
 export async function loadWasmModule(): Promise<LZMAModule> {
-  const wasmBinary = await readFile(WASM_FILE);
-
-  return initModule(async () => {
-    // Dynamic import of the Emscripten glue
-    const glueUrl = new URL(`file://${GLUE_FILE}`);
-    const { default: createLZMA } = await import(glueUrl.href);
-    return (await createLZMA({ wasmBinary })) as LZMAModule;
-  });
+  return initModule();
 }
 
 /**


### PR DESCRIPTION
## What

`node-liblzma/wasm` now loads with **zero configuration on Node and Deno** — `initModule()` reads the sibling `liblzma.wasm` from disk automatically. Previously the Emscripten glue (built for `web,worker`) resolved the binary via `import.meta.url` and fetched it, which fails on `file://` URLs outside a browser, so Node/Deno consumers had to supply a custom `wasmBinary` loader by hand.

## How

- The default loader detects Node/Deno and reads the binary itself, handing it to Emscripten as `wasmBinary`. Browsers keep the built-in fetch path unchanged.
- The `node:fs` / `node:url` imports are hidden from browser bundlers' static analysis (variable specifier + ignore comments) and guarded by a runtime check, so the browser bundle is unaffected.
- The test helper and the cross-runtime smoke drop their manual loaders and now exercise the zero-config path directly.
- `node-liblzma/inline` (base64-embedded) stays available for bundler-hostile environments; it is unchanged.

## Verification

- ✅ Full test suite green: 491 (root) + 214 (tar-xz) + 64 (nxz)
- ✅ 100% coverage maintained (statements / branches / functions / lines)
- ✅ Zero-config smoke passes on **Node 24** and **Deno 2.8.3**
- ✅ Browser example builds clean with Vite — no `node:` builtin leaks into the bundle, `.wasm` stays a 52 KB gzipped asset
- ✅ Lint + typecheck clean
