### PR TITLE
docs(wasm): document zero-config WASM loading on Node and Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ const decompressed = compressedStream.pipeThrough(createUnxz());
 | Import | When to use |
 |--------|-------------|
 | `node-liblzma` | Standard — bundler resolves to WASM (browser) or native (Node.js) |
-| `node-liblzma/wasm` | Explicit WASM usage in Node.js (no native addon needed) |
-| `node-liblzma/inline` | Zero-config — WASM embedded as base64 (no external file to serve) |
+| `node-liblzma/wasm` | Explicit WASM — **zero-config on Node & Deno** (auto-loads the sibling `.wasm`, no native addon); browser resolved by your bundler |
+| `node-liblzma/inline` | Zero-config everywhere — WASM embedded as base64 (no external file to serve) |
 
 ```typescript
-// Explicit WASM (works in Node.js too, no native build required)
+// Explicit WASM — zero-config on Node & Deno (auto-loads the sibling .wasm), no native build
 import { xzAsync } from 'node-liblzma/wasm';
 
 // Inline mode (larger bundle, but no WASM file to configure)

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -41,6 +41,18 @@ Forces WASM usage regardless of environment. Useful for Node.js when you don't w
 
 On **Node and Deno** this works with zero configuration — `initModule()` loads the sibling `liblzma.wasm` from disk automatically. In browsers the binary is resolved by your bundler (or fetched relative to the module URL). Pass a custom loader only to fetch the binary from a non-default location (see [Custom WASM Loading](#custom-wasm-loading)).
 
+```typescript
+// Node / Deno — no loader, no native build:
+import { xzAsync, unxzAsync } from 'node-liblzma/wasm';
+const compressed = await xzAsync('hello'); // buffer API auto-initializes
+const original = await unxzAsync(compressed);
+
+// The streaming API needs an explicit initModule() first:
+import { initModule, createXz, createUnxz } from 'node-liblzma/wasm';
+await initModule();
+const stream = createXz({ preset: 6 });
+```
+
 ### Inline WASM Import (zero-config)
 
 ```typescript


### PR DESCRIPTION
Documents the zero-config WASM loading on Node and Deno (shipped in #173): the README import table and the BROWSER.md guide no longer imply a custom loader is needed outside the browser, plus a concrete Node/Deno usage snippet. Pure docs — no code changes.