### PR TITLE
fix(build): use node-gyp-build install script so prebuilds are used under pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "./wasm/liblzma.wasm": "./lib/wasm/liblzma.wasm"
   },
   "scripts": {
-    "postinstall": "node-gyp-build",
+    "install": "node-gyp-build",
     "build": "tsc && node scripts/copy-wasm-artifacts.js",
     "build:wasm": "bash src/wasm/build.sh",
     "build:wasm:size": "bash src/wasm/build.sh --size-only",
@@ -128,7 +128,6 @@
     "binding",
     "native"
   ],
-  "gypfile": true,
   "author": "Olivier ORABONA",
   "license": "LGPL-3.0",
   "bugs": {


### PR DESCRIPTION
## What

Native prebuilds are now used under **pnpm** instead of a redundant from-source `node-gyp rebuild`.

## Why

The package declared `postinstall: node-gyp-build` alongside `gypfile: true`. The `gypfile` flag makes npm/pnpm run the default `node-gyp rebuild` (a source compile) during the install phase — *before* the `node-gyp-build` postinstall can select the shipped prebuild. Under pnpm's `onlyBuiltDependencies` allowlist this forces a from-source build that fails on machines without the native toolchain (no CMake / liblzma headers), and because the dependency is often optional, pnpm then silently drops it. Consumers on such CI (e.g. a pnpm monorepo without build tooling) end up with the module missing entirely.

## How

Switch to the canonical prebuildify layout:
- `install: node-gyp-build` (an explicit install script replaces the default `node-gyp rebuild`)
- drop `gypfile: true`

`node-gyp-build` selects the shipped prebuild directly, and falls back to a source build only when no prebuild matches the platform.

## Verification

- ✅ A/B under pnpm (allowlisted): before → `node-gyp rebuild` runs (source, `build/Release/*.node`); after → **no source build**, prebuild used, module loads + round-trips.
- ✅ npm: uses the prebuild, no source build, no regression.
- ✅ Full suite green (491 root + 214 tar-xz + 64 nxz), 100% coverage.
